### PR TITLE
Fix pip dependencies and build isolation for hstrat installation

### DIFF
--- a/slurm/2024-10-20/2024-10-20-example.sh
+++ b/slurm/2024-10-20/2024-10-20-example.sh
@@ -100,7 +100,7 @@ source "${BATCHDIR_ENV}/bin/activate"
 echo "python3.10 $(which python3.10)"
 echo "python3.10 --version $(python3.10 --version)"
 for attempt in {1..5}; do
-    python3.10 -m pip install --upgrade pip setuptools wheel || :
+    python3.10 -m pip install --upgrade pip 'setuptools<75' wheel || :
     python3.10 -m pip install --upgrade uv \
     && python3.10 -m uv pip install \
         'more_itertools==10.*' \
@@ -111,6 +111,9 @@ for attempt in {1..5}; do
         'pyarrow==15.*' \
         'scipy==1.*' \
         'tqdm==4.*' \
+        'cython>=0.29' \
+        'setuptools_scm>=2.0.0,<3' \
+    && python3.10 -m uv pip install --no-build-isolation \
         "git+${HSTRAT_REMOTE_URL}@${HSTRAT_REVISION}" \
     && break || echo "pip install attempt ${attempt} failed"
     if [ ${attempt} -eq 3 ]; then


### PR DESCRIPTION
## Summary
Updated the pip installation process to resolve dependency conflicts and enable proper build isolation when installing hstrat from git.

## Key Changes
- Constrained `setuptools` to version `<75` to avoid compatibility issues with the build process
- Added explicit dependencies:
  - `cython>=0.29` - required for building C extensions
  - `setuptools_scm>=2.0.0,<3` - needed for version detection during build
- Enabled `--no-build-isolation` flag for the hstrat installation to use the pre-installed build dependencies

## Implementation Details
These changes ensure that:
1. The setuptools version constraint prevents breaking changes in newer versions
2. Required build tools (Cython and setuptools_scm) are available before attempting to build hstrat from source
3. The build process uses the controlled environment rather than creating an isolated one, allowing it to leverage the pre-installed dependencies
4. The retry loop (1..5 attempts) continues to handle transient network failures

https://claude.ai/code/session_01V12tsU8Nv8B5BgAyuGAWme