### PR TITLE
Add rescale_stacked_kdeplot for log-scaling stacked KDE plots

### DIFF
--- a/pylib/__init__.py
+++ b/pylib/__init__.py
@@ -3,3 +3,8 @@ __email__ = "m.more500@gmail.com"
 __version__ = "0.0.0"
 
 from . import abm_2026_03_16  # noqa: F401
+from ._rescale_stacked_kdeplot import rescale_stacked_kdeplot
+
+__all__ = [
+    "rescale_stacked_kdeplot",
+]

--- a/pylib/_rescale_stacked_kdeplot.py
+++ b/pylib/_rescale_stacked_kdeplot.py
@@ -97,8 +97,7 @@ def rescale_stacked_kdeplot(
         Height-axis scale to render onto. Only ``"log"`` is implemented;
         any other value raises ``NotImplementedError``.
     vmin
-        Bottom of the log axis; must be > 0. Defaults to
-        ``max(total) / 1000`` — roughly three decades of range.
+        Bottom of the log axis; must be > 0. Defaults to ``1``.
 
     Returns
     -------
@@ -123,7 +122,7 @@ def rescale_stacked_kdeplot(
     contribs = [hi - lo for (_, lo, hi) in band_curves]
 
     if vmin is None:
-        vmin = max(float(totals.max()) / 1000.0, 1e-12)
+        vmin = 1.0
     elif vmin <= 0:
         raise ValueError("vmin must be > 0")
 

--- a/pylib/_rescale_stacked_kdeplot.py
+++ b/pylib/_rescale_stacked_kdeplot.py
@@ -97,7 +97,8 @@ def rescale_stacked_kdeplot(
         Height-axis scale to render onto. Only ``"log"`` is implemented;
         any other value raises ``NotImplementedError``.
     vmin
-        Bottom of the log axis; must be > 0. Defaults to ``1``.
+        Bottom of the log axis; must be > 0. Defaults to
+        ``max(total) / 1000`` — roughly three decades of range.
 
     Returns
     -------
@@ -122,7 +123,7 @@ def rescale_stacked_kdeplot(
     contribs = [hi - lo for (_, lo, hi) in band_curves]
 
     if vmin is None:
-        vmin = 1.0
+        vmin = max(float(totals.max()) / 1000.0, 1e-12)
     elif vmin <= 0:
         raise ValueError("vmin must be > 0")
 

--- a/pylib/_rescale_stacked_kdeplot.py
+++ b/pylib/_rescale_stacked_kdeplot.py
@@ -1,0 +1,166 @@
+"""Re-render a stacked seaborn KDE plot on a different height-axis scale.
+
+Each band keeps its linear share of the visual height, so band proportions
+look the same as on the original linear plot, but the overall envelope is
+compressed onto the requested scale (currently only ``"log"``).
+"""
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from matplotlib.axes import Axes
+import numpy as np
+
+try:
+    from matplotlib.collections import FillBetweenPolyCollection
+
+    _BAND_TYPES: Tuple[type, ...] = (FillBetweenPolyCollection,)
+except ImportError:  # matplotlib < 3.10
+    from matplotlib.collections import PolyCollection
+
+    _BAND_TYPES = (PolyCollection,)
+
+
+_VERTICAL = frozenset({"x", "v"})
+_HORIZONTAL = frozenset({"y", "h"})
+
+
+def _resolve_orient(orient: str) -> Tuple[int, int]:
+    """Map a seaborn ``orient`` to ``(data_axis_idx, height_axis_idx)``.
+
+    ``"x"`` / ``"v"`` mean the standard vertical KDE: data along x, density
+    along y. ``"y"`` / ``"h"`` mean the rotated horizontal KDE.
+    """
+    if orient in _VERTICAL:
+        return 0, 1
+    if orient in _HORIZONTAL:
+        return 1, 0
+    valid = sorted(_VERTICAL | _HORIZONTAL)
+    raise ValueError(f"orient must be one of {valid}, got {orient!r}")
+
+
+def _stacked_bands(ax: Axes) -> List:
+    bands = [c for c in ax.collections if isinstance(c, _BAND_TYPES)]
+    if not bands:
+        raise ValueError(
+            "No stacked-KDE band polygons found on these axes.",
+        )
+    return bands
+
+
+def _extract_band(
+    band, data_axis_idx: int
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ``(data, height_lower, height_upper)`` on a common data grid.
+
+    ``fill_between`` traces upper-left, lower-left, lower-edge along the
+    data axis, then jumps up and traces back along the upper edge.
+    Splitting at ``argmax`` of the data-axis coordinate cleanly separates
+    the two edges.
+    """
+    verts = band.get_paths()[0].vertices
+    height_idx = 1 - data_axis_idx
+    k = int(np.argmax(verts[:, data_axis_idx]))
+    lower = verts[1 : k + 1]
+    upper = verts[k + 1 :][::-1]
+    data = upper[:, data_axis_idx]
+    h_upper = upper[:, height_idx]
+    h_lower = np.interp(data, lower[:, data_axis_idx], lower[:, height_idx])
+    return data, h_lower, h_upper
+
+
+def rescale_stacked_kdeplot(
+    ax: Axes,
+    orient: str = "x",
+    *,
+    scale: str = "log",
+    vmin: float | None = None,
+) -> Axes:
+    """Re-render a stacked-KDE axes on a non-linear height-axis scale.
+
+    For ``scale="log"``, the top of the stacked envelope at column
+    :math:`d` is placed at :math:`\\log T(d)`. Inside that envelope,
+    band :math:`i`'s share of the visual (log-axis) height equals its
+    linear share :math:`d_i / T`, so band proportions look the same as
+    on a linear-scaled plot.
+
+    Parameters
+    ----------
+    ax
+        Axes containing a stacked seaborn ``kdeplot`` (``multiple="stack"``).
+    orient
+        Orientation in seaborn's convention. ``"x"`` / ``"v"`` for the
+        standard ``sns.kdeplot(x=...)`` (densities on the y-axis);
+        ``"y"`` / ``"h"`` for the rotated ``sns.kdeplot(y=...)``
+        (densities on the x-axis).
+    scale
+        Height-axis scale to render onto. Only ``"log"`` is implemented;
+        any other value raises ``NotImplementedError``.
+    vmin
+        Bottom of the log axis; must be > 0. Defaults to
+        ``max(total) / 1000`` — roughly three decades of range.
+
+    Returns
+    -------
+    Axes
+        The same axes, modified in place.
+    """
+    if scale != "log":
+        raise NotImplementedError(
+            f"scale={scale!r} is not implemented; only 'log' is supported.",
+        )
+    data_axis_idx, height_axis_idx = _resolve_orient(orient)
+
+    bands = _stacked_bands(ax)
+    colors = [c.get_facecolor()[0] for c in bands]
+    edgecolors = [c.get_edgecolor() for c in bands]
+    linewidths = [c.get_linewidth() for c in bands]
+    linestyles = [c.get_linestyle() for c in bands]
+
+    band_curves = [_extract_band(b, data_axis_idx) for b in bands]
+    data_grid = band_curves[0][0]
+    totals = band_curves[-1][2]
+    contribs = [hi - lo for (_, lo, hi) in band_curves]
+
+    if vmin is None:
+        vmin = max(float(totals.max()) / 1000.0, 1e-12)
+    elif vmin <= 0:
+        raise ValueError("vmin must be > 0")
+
+    safe_totals = np.where(totals > 0, totals, vmin)
+
+    new_edges = []
+    cum_prop = np.zeros_like(totals)
+    prev_edge = np.full_like(totals, vmin)
+    for d_i in contribs:
+        prop = np.where(totals > 0, d_i / safe_totals, 0.0)
+        cum_prop = cum_prop + prop
+        new_edge = vmin * (safe_totals / vmin) ** cum_prop
+        new_edges.append((prev_edge.copy(), new_edge.copy()))
+        prev_edge = new_edge
+
+    for c in bands:
+        c.remove()
+
+    fill_fn = ax.fill_between if height_axis_idx == 1 else ax.fill_betweenx
+    for color, ec, lw, ls, (lo, hi) in zip(
+        colors, edgecolors, linewidths, linestyles, new_edges
+    ):
+        fill_fn(
+            data_grid,
+            lo,
+            hi,
+            facecolor=color,
+            edgecolor=ec,
+            linewidth=lw,
+            linestyle=ls,
+        )
+
+    if height_axis_idx == 1:
+        ax.set_yscale("log")
+        ax.set_ylim(vmin, None)
+    else:
+        ax.set_xscale("log")
+        ax.set_xlim(vmin, None)
+
+    return ax

--- a/tests/test_pylib/test_rescale_stacked_kdeplot.py
+++ b/tests/test_pylib/test_rescale_stacked_kdeplot.py
@@ -100,6 +100,13 @@ def test_default_scale_is_log():
     plt.close(fig)
 
 
+def test_default_vmin_is_one():
+    fig, ax = _make_stacked_kde()
+    rescale_stacked_kdeplot(ax, "x")
+    assert ax.get_ylim()[0] == pytest.approx(1.0)
+    plt.close(fig)
+
+
 def test_vmin_overrides_default():
     fig, ax = _make_stacked_kde()
     rescale_stacked_kdeplot(ax, orient="x", vmin=1e-3)

--- a/tests/test_pylib/test_rescale_stacked_kdeplot.py
+++ b/tests/test_pylib/test_rescale_stacked_kdeplot.py
@@ -100,13 +100,6 @@ def test_default_scale_is_log():
     plt.close(fig)
 
 
-def test_default_vmin_is_one():
-    fig, ax = _make_stacked_kde()
-    rescale_stacked_kdeplot(ax, "x")
-    assert ax.get_ylim()[0] == pytest.approx(1.0)
-    plt.close(fig)
-
-
 def test_vmin_overrides_default():
     fig, ax = _make_stacked_kde()
     rescale_stacked_kdeplot(ax, orient="x", vmin=1e-3)

--- a/tests/test_pylib/test_rescale_stacked_kdeplot.py
+++ b/tests/test_pylib/test_rescale_stacked_kdeplot.py
@@ -1,0 +1,161 @@
+"""Tests for pylib.rescale_stacked_kdeplot."""
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+from pylib import rescale_stacked_kdeplot  # noqa: E402
+from pylib._rescale_stacked_kdeplot import (  # noqa: E402
+    _extract_band,
+    _stacked_bands,
+)
+
+
+def _make_stacked_kde(orient="x"):
+    tips = sns.load_dataset("tips")
+    fig, ax = plt.subplots()
+    if orient in ("x", "v"):
+        sns.kdeplot(
+            data=tips,
+            x="total_bill",
+            hue="time",
+            multiple="stack",
+            ax=ax,
+        )
+    else:
+        sns.kdeplot(
+            data=tips,
+            y="total_bill",
+            hue="time",
+            multiple="stack",
+            ax=ax,
+        )
+    return fig, ax
+
+
+@pytest.mark.parametrize("orient", ["x", "v"])
+def test_vertical_orientations(orient):
+    fig, ax = _make_stacked_kde("x")
+    out = rescale_stacked_kdeplot(ax, orient=orient)
+    assert out is ax
+    assert ax.get_yscale() == "log"
+    assert ax.get_xscale() == "linear"
+    plt.close(fig)
+
+
+@pytest.mark.parametrize("orient", ["y", "h"])
+def test_horizontal_orientations(orient):
+    fig, ax = _make_stacked_kde("y")
+    out = rescale_stacked_kdeplot(ax, orient=orient)
+    assert out is ax
+    assert ax.get_xscale() == "log"
+    assert ax.get_yscale() == "linear"
+    plt.close(fig)
+
+
+def test_orient_positional():
+    fig, ax = _make_stacked_kde("x")
+    rescale_stacked_kdeplot(ax, "x")
+    assert ax.get_yscale() == "log"
+    plt.close(fig)
+
+
+def test_invalid_orient_raises():
+    fig, ax = _make_stacked_kde()
+    with pytest.raises(ValueError):
+        rescale_stacked_kdeplot(ax, orient="bogus")
+    plt.close(fig)
+
+
+def test_invalid_vmin_raises():
+    fig, ax = _make_stacked_kde()
+    with pytest.raises(ValueError):
+        rescale_stacked_kdeplot(ax, orient="x", vmin=0)
+    plt.close(fig)
+
+
+def test_no_bands_raises():
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [1, 2, 3])
+    with pytest.raises(ValueError):
+        rescale_stacked_kdeplot(ax, orient="x")
+    plt.close(fig)
+
+
+def test_unsupported_scale_raises():
+    fig, ax = _make_stacked_kde()
+    with pytest.raises(NotImplementedError):
+        rescale_stacked_kdeplot(ax, orient="x", scale="symlog")
+    plt.close(fig)
+
+
+def test_default_scale_is_log():
+    fig, ax = _make_stacked_kde()
+    rescale_stacked_kdeplot(ax, "x")
+    assert ax.get_yscale() == "log"
+    plt.close(fig)
+
+
+def test_vmin_overrides_default():
+    fig, ax = _make_stacked_kde()
+    rescale_stacked_kdeplot(ax, orient="x", vmin=1e-3)
+    assert ax.get_ylim()[0] == pytest.approx(1e-3)
+    plt.close(fig)
+
+
+def test_band_count_unchanged():
+    fig, ax = _make_stacked_kde("x")
+    n_before = len(_stacked_bands(ax))
+    rescale_stacked_kdeplot(ax, orient="x")
+    n_after = len(_stacked_bands(ax))
+    assert n_after == n_before
+    plt.close(fig)
+
+
+@pytest.mark.parametrize("orient", ["x", "y"])
+def test_band_proportions_preserved_at_peak(orient):
+    """Log-axis band shares should match the original linear shares."""
+    data_axis_idx = 0 if orient == "x" else 1
+
+    fig0, ax0 = _make_stacked_kde(orient)
+    bands0 = _stacked_bands(ax0)
+    curves0 = [_extract_band(b, data_axis_idx) for b in bands0]
+    totals = curves0[-1][2]
+    peak_i = int(np.argmax(totals))
+    linear_props = [
+        (hi[peak_i] - lo[peak_i]) / totals[peak_i] for (_, lo, hi) in curves0
+    ]
+    plt.close(fig0)
+
+    fig, ax = _make_stacked_kde(orient)
+    rescale_stacked_kdeplot(ax, orient=orient)
+    bands = _stacked_bands(ax)
+    curves = [_extract_band(b, data_axis_idx) for b in bands]
+    totals_log = curves[-1][2]
+    peak_log = int(np.argmax(totals_log))
+    if orient == "x":
+        bottom = ax.get_ylim()[0]
+    else:
+        bottom = ax.get_xlim()[0]
+    span = np.log(totals_log[peak_log]) - np.log(bottom)
+    log_props = []
+    prev = np.log(bottom)
+    for (_, _, hi) in curves:
+        top = np.log(hi[peak_log])
+        log_props.append((top - prev) / span)
+        prev = top
+    plt.close(fig)
+
+    np.testing.assert_allclose(log_props, linear_props, atol=1e-6)
+
+
+def test_height_axis_log_lower_bound_matches_vmin():
+    fig, ax = _make_stacked_kde("x")
+    rescale_stacked_kdeplot(ax, orient="x", vmin=5e-4)
+    assert ax.get_yscale() == "log"
+    assert ax.get_ylim()[0] == pytest.approx(5e-4)
+    plt.close(fig)


### PR DESCRIPTION
Re-renders a stacked seaborn kdeplot onto a log-scaled height axis
while preserving each band's linear share of the visual height. Accepts
seaborn-style orient values ('x'/'v' vertical, 'y'/'h' horizontal) and
exposes a scale='log' parameter that raises NotImplementedError for
other scales.

https://claude.ai/code/session_01MqVFN3MVUPA9aDxqKfEy2x