### PR TITLE
Add newline to watermark extension load statement

### DIFF
--- a/binder/2024-10-20-example.ipynb
+++ b/binder/2024-10-20-example.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load_ext watermark"
+    "%load_ext watermark\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
Minor formatting fix to the notebook cell containing the watermark extension loader.

## Changes
- Added trailing newline to the `%load_ext watermark` magic command in the notebook cell

## Details
This change ensures consistent formatting and proper line ending in the notebook source code. The modification adds a newline character at the end of the magic command, which is a best practice for notebook cell formatting.

https://claude.ai/code/session_0141FchZWG1PJ8c2FykRWbcU