### PR TITLE
Add R-per-strain ABM notebook with phylogeny tracking

### DIFF
--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -129,8 +129,7 @@ def configure_backend(ENGINE, cp, np):
 
 @app.cell(hide_code=True)
 def delimit_simulation(mo):
-    mo.md(
-        """
+    mo.md("""
     ## Simulation Implementation
 
     This notebook is an R-per-strain companion to
@@ -140,16 +139,32 @@ def delimit_simulation(mo):
     individual strain (the strain count is `2**N_SITES`, capped here
     at 16). In addition to the phylogeny-and-strain-network plots
     inherited from the 32-site notebook, this notebook renders an
-    "r-curves" figure: two vertically-stacked panels sharing the
-    time axis, with the *theoretical* per-strain reproduction number
-    `R_theo(t, s) = (CONTACT_RATE / RECOVERY_RATE) * S_s(t)` (dashed,
-    using the product of per-allele susceptibilities as the strain
-    susceptibility proxy) on top, and the *actual* per-strain
-    reproduction number `R_actual(t, s) = 1 + (1/RECOVERY_RATE) *
-    d ln(I_s)/dt` (solid, derived from the prevalence trajectory via
-    centered finite differences on log-prevalence) on bottom, color-
-    coded by strain. `R = 1` is the epidemic threshold: strains above
-    are growing, strains below are shrinking.
+    "r-curves" figure: a multi-row stack (one row per smoothing
+    window, unsmoothed at the top) plotting both *actual* and
+    *theoretical* per-strain reproduction numbers, defined per step
+    (rather than per infectious period) so that they can be compared
+    apples-to-apples against directly-observed transmission events:
+
+    * `R_actual(t, s) = new_infections(s, t) / n_with_strain(s, t)` --
+      the number of new strain-`s` infections caused per current
+      strain-`s` infected per step, computed from instrumentation
+      logged inside `simulate()`. `new_infections` is captured
+      pre-mutation in `update_simulation()` so the strain label
+      reflects the strain that actually transmitted, not its
+      post-mutation descendant.
+
+    * `R_theo(t, s)` -- the average over the population of the
+      probability that strain `s` infects a randomly-sampled
+      individual on a single contact in one step (infected hosts
+      contribute zero since they cannot be re-infected), so
+      `R_theo(s, t) * n_with_strain(s, t)` is the expected number of
+      new strain-`s` infections per step. This is logged per step as
+      `strain_df["theoretical_R"]` alongside `count` and
+      `new_infections`.
+
+    Both are plotted as line curves color-coded by strain; actual is
+    rolling-mean smoothed with the row's window, theoretical is left
+    unsmoothed (it is already a smooth function of population state).
 
     Phylogeny estimation still uses *hereditary stratigraphic surface*
     annotations (see https://hstrat.rtfd.io). Each infected host carries
@@ -161,8 +176,7 @@ def delimit_simulation(mo):
 
     The vectorized deposit pattern is adapted from
     https://github.com/mmore500/hstrat-synthesis (see `pylib/track_ca.py`).
-    """
-    )
+    """)
     return
 
 
@@ -387,7 +401,7 @@ def def_simulate(
             pathogen_genomes: xp.ndarray,
             host_immunities: xp.ndarray,
             pathogen_markers: xp.ndarray,
-        ) -> Tuple[xp.ndarray, xp.ndarray, xp.ndarray]:
+        ) -> Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]:
             contacts = xp.random.randint(
                 low=0, high=POP_SIZE, size=POP_SIZE, dtype=xp.uint32
             )
@@ -409,7 +423,12 @@ def def_simulate(
                 new_infections
             ]
 
-            return host_statuses, pathogen_genomes, pathogen_markers
+            return (
+                host_statuses,
+                pathogen_genomes,
+                pathogen_markers,
+                new_infections,
+            )
 
         def apply_mutations(
             pathogen_genomes: xp.ndarray,
@@ -460,17 +479,19 @@ def def_simulate(
             host_immunities: xp.ndarray,
             pathogen_markers: xp.ndarray,
             t: int,
-        ) -> Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]:
+        ) -> Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]:
             (
                 host_statuses,
                 pathogen_genomes,
                 pathogen_markers,
+                new_infections,
             ) = transmit_infection(
                 host_statuses,
                 pathogen_genomes,
                 host_immunities,
                 pathogen_markers,
             )
+            new_strain_genomes = pathogen_genomes[new_infections].copy()
             pathogen_genomes = apply_mutations(pathogen_genomes, host_statuses)
             host_statuses, host_immunities = update_recoveries(
                 host_statuses, host_immunities, pathogen_genomes
@@ -483,6 +504,7 @@ def def_simulate(
                 pathogen_genomes,
                 host_immunities,
                 pathogen_markers,
+                new_strain_genomes,
             )
 
         (
@@ -499,12 +521,23 @@ def def_simulate(
         strain_log: List[Dict[str, float]] = []
         n_strains = 1 << N_SITES
 
+        # Precomputed per-(strain, site) susceptibility-column indices
+        # (a strain's allele bit at each site selects which of the two
+        # per-allele susc entries enters the per-strain product).
+        _strain_idx = xp.arange(n_strains, dtype=xp.int64)
+        _site_idx = xp.arange(N_SITES, dtype=xp.int64)
+        _strain_bits = (_strain_idx[:, None] >> _site_idx[None, :]) & 1
+        _strain_cols = (2 * _site_idx[None, :] + _strain_bits).astype(
+            xp.int64,
+        )
+
         for t in tqdm(range(N_STEPS), mininterval=20.0):
             (
                 host_statuses,
                 pathogen_genomes,
                 host_immunities,
                 pathogen_markers,
+                new_strain_genomes,
             ) = update_simulation(
                 host_statuses,
                 pathogen_genomes,
@@ -536,6 +569,38 @@ def def_simulate(
                     float(c) / POP_SIZE for c in strain_counts_arr.tolist()
                 ]
 
+            # Per-strain new infections this step (population fraction).
+            # Captured pre-mutation in update_simulation so the strain
+            # label is the strain that actually transmitted.
+            if new_strain_genomes.size > 0:
+                new_strain_counts_arr = xp.bincount(
+                    new_strain_genomes.astype(xp.int64),
+                    minlength=n_strains,
+                )
+                new_strain_counts = [
+                    float(c) / POP_SIZE for c in new_strain_counts_arr.tolist()
+                ]
+            else:
+                new_strain_counts = [0.0] * n_strains
+
+            # Per-strain theoretical R per current infected per step:
+            # average over the population of P(strain s infects a random
+            # individual in one step), counting infected hosts as 0 since
+            # they cannot be re-infected. Multiplying by n(s, t) gives
+            # the expected number of new strain-s infections per step.
+            host_susc_2d = (1.0 - (IMMUNE_STRENGTH * host_immunities)).reshape(
+                POP_SIZE, 2 * N_SITES
+            )
+            strain_susc_per_host = host_susc_2d[:, _strain_cols].prod(axis=2)
+            strain_susc_per_host = xp.power(strain_susc_per_host, pow)
+            strain_susc_per_host = (
+                strain_susc_per_host * (host_statuses == 0)[:, None]
+            )
+            theo_R_per_strain = (
+                strain_susc_per_host.mean(axis=0) * CONTACT_RATE
+            )
+            theo_R_list = [float(x) for x in theo_R_per_strain.tolist()]
+
             for w, count in enumerate(hw_prevalences):
                 hw_log.append(
                     {
@@ -553,6 +618,8 @@ def def_simulate(
                         "Seed": seed,
                         "strain": s,
                         "count": count,
+                        "new_infections": new_strain_counts[s],
+                        "theoretical_R": theo_R_list[s],
                     }
                 )
 
@@ -664,8 +731,7 @@ def def_simulate(
 
 @app.cell(hide_code=True)
 def delimit_reconstruct(mo):
-    mo.md(
-        """
+    mo.md("""
     ## Surface-Annotation Reconstruction
 
     Given the snapshot records emitted by `simulate(..., track_phylogeny=
@@ -673,8 +739,7 @@ def delimit_reconstruct(mo):
     `hstrat.dataframe.surface_postprocess_trie` to estimate the phylogenetic
     tree. We use `AssignOriginTimeNodeRankTriePostprocessor(t0="dstream_S")`
     so that origin times line up with simulation step numbers.
-    """
-    )
+    """)
     return
 
 
@@ -707,14 +772,12 @@ def def_reconstruct_phylogeny(gc, hstrat, pd, pl):
 
 @app.cell(hide_code=True)
 def delimit_phylogeny(mo):
-    mo.md(
-        """
+    mo.md("""
     ## Surface-Reconstructed Phylogeny
 
     Sweep `N_SITES` over a few values and render the surface-reconstructed
     phylogeny next to the absolute-prevalence and Hamming-weight stackplots.
-    """
-    )
+    """)
     return
 
 
@@ -1269,120 +1332,116 @@ def def_make_allele_curves_plot(allele_palette, np, pathlib, plt, sns, tp):
 
 
 @app.cell
-def def_make_r_curves_plot(np, pathlib, plt, sns, strain_palette, tp):
+def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
     def make_r_curves_plot(
         N_SITES: int,
-        traj_df,
         strain_df,
-        CONTACT_RATE: float,
-        RECOVERY_RATE: float,
-        POP_SIZE: int,
-        prev_floor: float = 1.0,
+        smoothing_windows=(1, 5, 25, 125),
         palette: str = "husl",
         teeplot_outattrs: dict = {},
     ) -> None:
-        """Two-panel stacked figure of per-strain reproduction number:
-        top = theoretical R(t, s) = (CONTACT_RATE/RECOVERY_RATE) * S_s(t)
-        (dashed; S_s(t) is approximated as the product of per-allele
-        population-average susceptibilities for the bits of strain s);
-        bottom = actual R(t, s) = 1 + (1/RECOVERY_RATE) * d ln I_s / dt
-        (solid; I_s(t) read from `strain_df['count']`, which carries the
-        per-strain population-fraction prevalence; the log-derivative is
-        computed via `np.gradient` and masked where `I_s * POP_SIZE` is
-        below `prev_floor` infected hosts to avoid amplifying
-        quantization noise from low-occupancy strains). Strains are
-        color-coded by Hamming weight (hue) with lightness disambiguating
-        strains that share a Hamming weight. R = 1 is drawn as a dotted
-        reference line on both panels.
+        """Multi-row figure of per-strain reproduction number, one row
+        per smoothing window (unsmoothed at the top). In each row,
+        actual R(t, s) = new_infections(s, t) / n_with_strain(s, t)
+        (solid; computed directly from the per-step instrumentation
+        logged in `strain_df`: `new_infections` is the population
+        fraction newly infected with strain s in the step, captured
+        pre-mutation, and `count` is the population fraction currently
+        infected with strain s) is overlaid with theoretical R(t, s)
+        (dashed; logged per step as `theoretical_R`, equal to the
+        average over the population of P(strain s infects a randomly-
+        sampled individual on a single contact in one step), with
+        infected hosts contributing 0 since they cannot be re-infected
+        --- so theoretical_R(s, t) * n_with_strain(s, t) is the
+        expected number of new strain-s infections per step). The
+        actual R is rolling-mean smoothed with the row's window;
+        theoretical R is plotted unsmoothed (it is already a smooth
+        function of population state). Strains are color-coded by
+        Hamming weight (hue) with lightness disambiguating strains of
+        the same weight. The first row's window is always 1 (no
+        smoothing).
         """
         n_strains = 1 << N_SITES
-        traj_df = traj_df.sort_values("Step")
-        steps = traj_df["Step"].to_numpy(dtype=float)
-
-        susc_by_site_bit = np.empty((len(traj_df), N_SITES, 2), dtype=float)
-        for site in range(N_SITES):
-            for bit in range(2):
-                susc_by_site_bit[:, site, bit] = traj_df[
-                    f"Susc_S{site}_B{bit}"
-                ].to_numpy()
-
-        susc_per_strain = np.ones((len(traj_df), n_strains), dtype=float)
-        for s in range(n_strains):
-            for site in range(N_SITES):
-                bit = (s >> site) & 1
-                susc_per_strain[:, s] *= susc_by_site_bit[:, site, bit]
-
-        R0 = CONTACT_RATE / RECOVERY_RATE
-        r_theo_per_strain = R0 * susc_per_strain
 
         unique_steps = np.array(
             sorted(strain_df["Step"].unique()), dtype=float
         )
-        prev_per_strain = np.zeros((len(unique_steps), n_strains), dtype=float)
+        T = len(unique_steps)
         step_to_idx = {t: i for i, t in enumerate(unique_steps.tolist())}
-        for s in range(n_strains):
-            sub = strain_df[strain_df["strain"] == s]
-            for _, row in sub.iterrows():
-                prev_per_strain[step_to_idx[row["Step"]], s] = float(
-                    row["count"]
-                )
 
-        r_actual_per_strain = np.full_like(prev_per_strain, np.nan)
-        for s in range(n_strains):
-            i_s = prev_per_strain[:, s]
-            valid = i_s * POP_SIZE > prev_floor
-            if valid.sum() < 3:
-                continue
-            log_i = np.full_like(i_s, np.nan)
-            log_i[valid] = np.log(i_s[valid])
-            dlog_dt = np.gradient(log_i, unique_steps)
-            r = 1.0 + dlog_dt / RECOVERY_RATE
-            r_actual_per_strain[valid, s] = r[valid]
+        prev_per_strain = np.zeros((T, n_strains), dtype=float)
+        new_inf_per_strain = np.zeros((T, n_strains), dtype=float)
+        theo_R_per_strain = np.zeros((T, n_strains), dtype=float)
+
+        for _, row in strain_df.iterrows():
+            i = step_to_idx[row["Step"]]
+            s = int(row["strain"])
+            prev_per_strain[i, s] = float(row["count"])
+            new_inf_per_strain[i, s] = float(row.get("new_infections", 0.0))
+            theo_R_per_strain[i, s] = float(row.get("theoretical_R", 0.0))
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            r_actual_per_strain = np.where(
+                prev_per_strain > 0,
+                new_inf_per_strain / prev_per_strain,
+                np.nan,
+            )
 
         palette_colors = strain_palette(N_SITES, base_palette=palette)
 
+        windows = list(smoothing_windows)
+        if not windows or windows[0] != 1:
+            windows = [1] + windows
+
         with tp.teed(
             plt.subplots,
-            nrows=2,
+            nrows=len(windows),
             ncols=1,
-            figsize=(8, 6),
+            figsize=(8, 2.0 * len(windows) + 1.0),
             sharex=True,
-            gridspec_kw={"hspace": 0.05},
+            gridspec_kw={"hspace": 0.08},
             teeplot_outattrs=teeplot_outattrs,
             teeplot_show=True,
             teeplot_subdir=pathlib.Path(__file__).stem,
         ) as (fig, axes):
-            ax_theo, ax_actual = axes
+            if len(windows) == 1:
+                axes = [axes]
 
-            for s in range(n_strains):
-                color = palette_colors[s]
-                label = f"{s:0{N_SITES}b}"
-                ax_theo.plot(
-                    steps,
-                    r_theo_per_strain[:, s],
-                    color=color,
-                    linestyle="--",
-                    linewidth=1.5,
-                    label=label,
+            for ax, w in zip(axes, windows):
+                for s in range(n_strains):
+                    color = palette_colors[s]
+                    label = f"{s:0{N_SITES}b}"
+                    actual = pd.Series(r_actual_per_strain[:, s])
+                    if w > 1:
+                        actual = actual.rolling(
+                            window=w,
+                            min_periods=max(1, w // 4),
+                            center=True,
+                        ).mean()
+                    ax.plot(
+                        unique_steps,
+                        actual.to_numpy(),
+                        color=color,
+                        linestyle="-",
+                        linewidth=1.2,
+                        label=label,
+                    )
+                    ax.plot(
+                        unique_steps,
+                        theo_R_per_strain[:, s],
+                        color=color,
+                        linestyle="--",
+                        linewidth=1.2,
+                    )
+                ax.axhline(0.0, color="gray", linestyle=":", linewidth=0.8)
+                window_label = (
+                    "unsmoothed" if w == 1 else f"rolling mean, window={w}"
                 )
-                ax_actual.plot(
-                    unique_steps,
-                    r_actual_per_strain[:, s],
-                    color=color,
-                    linestyle="-",
-                    linewidth=1.5,
-                    label=label,
-                )
+                ax.set_ylabel(f"R per step\n({window_label})")
+                sns.despine(ax=ax)
 
-            for ax in (ax_theo, ax_actual):
-                ax.axhline(1.0, color="gray", linestyle=":", linewidth=1.0)
-
-            ax_theo.set_ylabel(r"theoretical $R(t)$")
-            ax_theo.set_ylim(bottom=0.0)
-            ax_actual.set_ylabel(r"actual $R(t)$")
-            ax_actual.set_xlabel("Time")
-
-            ax_theo.legend(
+            axes[-1].set_xlabel("Time")
+            axes[0].legend(
                 title="strain",
                 loc="center left",
                 bbox_to_anchor=(1.02, 0.5),
@@ -1391,8 +1450,11 @@ def def_make_r_curves_plot(np, pathlib, plt, sns, strain_palette, tp):
                 ncol=1 if n_strains <= 8 else 2,
                 fontsize=8,
             )
-            sns.despine(ax=ax_theo)
-            sns.despine(ax=ax_actual)
+            axes[0].set_title(
+                "actual (solid) vs. theoretical (dashed) "
+                "per-strain new infections per current infected per step",
+                fontsize=10,
+            )
 
     return (make_r_curves_plot,)
 
@@ -1522,11 +1584,7 @@ def run_phylogeny_sweep(
                     )
                     make_r_curves_plot(
                         PHYLO_N_SITES,
-                        _phylo_df,
                         _strain_df,
-                        CONTACT_RATE=CONTACT_RATE_,
-                        RECOVERY_RATE=RECOVERY_RATE_,
-                        POP_SIZE=POP_SIZE,
                         palette=palette,
                         teeplot_outattrs={
                             "a": "r-curves",

--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -129,7 +129,8 @@ def configure_backend(ENGINE, cp, np):
 
 @app.cell(hide_code=True)
 def delimit_simulation(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Simulation Implementation
 
     This notebook is an R-per-strain companion to
@@ -176,7 +177,8 @@ def delimit_simulation(mo):
 
     The vectorized deposit pattern is adapted from
     https://github.com/mmore500/hstrat-synthesis (see `pylib/track_ca.py`).
-    """)
+    """
+    )
     return
 
 
@@ -731,7 +733,8 @@ def def_simulate(
 
 @app.cell(hide_code=True)
 def delimit_reconstruct(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Surface-Annotation Reconstruction
 
     Given the snapshot records emitted by `simulate(..., track_phylogeny=
@@ -739,7 +742,8 @@ def delimit_reconstruct(mo):
     `hstrat.dataframe.surface_postprocess_trie` to estimate the phylogenetic
     tree. We use `AssignOriginTimeNodeRankTriePostprocessor(t0="dstream_S")`
     so that origin times line up with simulation step numbers.
-    """)
+    """
+    )
     return
 
 
@@ -772,12 +776,14 @@ def def_reconstruct_phylogeny(gc, hstrat, pd, pl):
 
 @app.cell(hide_code=True)
 def delimit_phylogeny(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Surface-Reconstructed Phylogeny
 
     Sweep `N_SITES` over a few values and render the surface-reconstructed
     phylogeny next to the absolute-prevalence and Hamming-weight stackplots.
-    """)
+    """
+    )
     return
 
 

--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -140,35 +140,39 @@ def delimit_simulation(mo):
     individual strain (the strain count is `2**N_SITES`, capped here
     at 16). In addition to the phylogeny-and-strain-network plots
     inherited from the 32-site notebook, this notebook renders an
-    "r-curves" figure: a multi-row stack with the *theoretical* per-
+    "r-curves" figure: a multi-row stack with the *expected* per-
     strain reproduction number on the very top row by itself, and
-    the *actual* per-strain reproduction number on subsequent rows
-    at increasing smoothing windows (unsmoothed first). Both are
-    scaled by the expected infectious period `1 / RECOVERY_RATE` so
-    the plotted values are total expected new infections per
+    the *empirical* per-strain reproduction number on subsequent
+    rows at increasing rolling-mean windows (unsmoothed first). Both
+    are scaled by the expected infectious period `1 / RECOVERY_RATE`
+    so the plotted values are total expected new infections per
     infected over an infection (i.e. an `R0`-like quantity) rather
     than the per-step rate, and `R = 1` is drawn as the
     epidemic-threshold reference line.
 
-    * `R_actual(t, s) = new_infections(s, t) / n_with_strain(s, t) /
-      RECOVERY_RATE` -- the number of new strain-`s` infections
-      caused per current strain-`s` infected per step, multiplied by
-      the expected infectious period, computed from instrumentation
-      logged inside `simulate()`. `new_infections` is captured
-      pre-mutation in `update_simulation()` so the strain label
-      reflects the strain that actually transmitted, not its
-      post-mutation descendant.
+    * `R_empirical(t, s) = new_infections(s, t) /
+      n_with_strain(s, t) / RECOVERY_RATE` -- the number of new
+      strain-`s` infections caused per current strain-`s` infected
+      per step, multiplied by the expected infectious period,
+      computed from instrumentation logged inside `simulate()`.
+      `new_infections` is captured pre-mutation in
+      `update_simulation()` so the strain label reflects the strain
+      that actually transmitted, not its post-mutation descendant.
 
-    * `R_theo(t, s) = R_theo_per_step(s, t) / RECOVERY_RATE`, where
-      `R_theo_per_step(s, t)` is the average over the population of
-      the probability that strain `s` infects a randomly-sampled
-      individual on a single contact in one step (infected hosts
-      contribute zero since they cannot be re-infected). The per-
-      step quantity is logged as `strain_df["theoretical_R"]`
-      alongside `count` and `new_infections`; multiplying by the
-      expected infectious period gives the analog of `R0` (so
-      `R_theo(s, t) * n_with_strain(s, t) * RECOVERY_RATE` is the
-      expected number of new strain-`s` infections per step).
+    * `R_expected(t, s) = R_expected_per_step(s, t) / RECOVERY_RATE`,
+      where `R_expected_per_step(s, t)` is the average over the
+      population of the probability that strain `s` infects a
+      randomly-sampled individual on a single contact in one step.
+      Currently-infected hosts contribute zero since they cannot be
+      re-infected --- the `(host_statuses == 0)` mask zeros out
+      their per-host susceptibilities before averaging over the full
+      `POP_SIZE`, so the mean already accounts for the susceptible-
+      only fraction. The per-step quantity is logged as
+      `strain_df["expected_R"]` alongside `count` and
+      `new_infections`; multiplying by the expected infectious
+      period gives the analog of `R0` (so `R_expected(s, t) *
+      n_with_strain(s, t) * RECOVERY_RATE` is the expected number of
+      new strain-`s` infections per step).
 
     Phylogeny estimation still uses *hereditary stratigraphic surface*
     annotations (see https://hstrat.rtfd.io). Each infected host carries
@@ -588,11 +592,15 @@ def def_simulate(
             else:
                 new_strain_counts = [0.0] * n_strains
 
-            # Per-strain theoretical R per current infected per step:
+            # Per-strain expected R per current infected per step:
             # average over the population of P(strain s infects a random
-            # individual in one step), counting infected hosts as 0 since
-            # they cannot be re-infected. Multiplying by n(s, t) gives
-            # the expected number of new strain-s infections per step.
+            # individual in one step). Currently-infected hosts
+            # contribute 0 since they cannot be re-infected --- the
+            # `(host_statuses == 0)` mask zeros out their per-host
+            # entries before averaging over the full POP_SIZE, so the
+            # mean already accounts for the susceptible-only fraction.
+            # Multiplying by n(s, t) gives the expected number of new
+            # strain-s infections per step.
             host_susc_2d = (1.0 - (IMMUNE_STRENGTH * host_immunities)).reshape(
                 POP_SIZE, 2 * N_SITES
             )
@@ -601,10 +609,12 @@ def def_simulate(
             strain_susc_per_host = (
                 strain_susc_per_host * (host_statuses == 0)[:, None]
             )
-            theo_R_per_strain = (
+            expected_R_per_strain = (
                 strain_susc_per_host.mean(axis=0) * CONTACT_RATE
             )
-            theo_R_list = [float(x) for x in theo_R_per_strain.tolist()]
+            expected_R_list = [
+                float(x) for x in expected_R_per_strain.tolist()
+            ]
 
             for w, count in enumerate(hw_prevalences):
                 hw_log.append(
@@ -624,7 +634,7 @@ def def_simulate(
                         "strain": s,
                         "count": count,
                         "new_infections": new_strain_counts[s],
-                        "theoretical_R": theo_R_list[s],
+                        "expected_R": expected_R_list[s],
                     }
                 )
 
@@ -1351,26 +1361,27 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
         teeplot_outattrs: dict = {},
     ) -> None:
         """Multi-row figure of per-strain reproduction number. The
-        first row plots the *theoretical* R per strain on its own,
-        and each subsequent row plots the *actual* R per strain at a
-        different smoothing window (unsmoothed first). Both are
+        first row plots the *expected* R per strain on its own; each
+        subsequent row plots the *empirical* R per strain at a
+        different rolling-mean window (unsmoothed first). Both are
         scaled by the expected infectious period `1 / RECOVERY_RATE`
         so the plotted values are total expected new infections per
         infected over an infection (an `R0`-like quantity), not the
         per-step rate.
 
-        * actual R(t, s) = (new_infections(s, t) / n_with_strain(s, t))
-          * (1 / RECOVERY_RATE) -- new strain-s infections per current
-          strain-s infected per step, multiplied by the expected
-          infectious period in steps. Rolling-mean smoothed with the
-          row's window.
-        * theoretical R(t, s) = theoretical_R_per_step(s, t) *
-          (1 / RECOVERY_RATE) where the per-step quantity is the
+        * empirical R(t, s) = (new_infections(s, t) /
+          n_with_strain(s, t)) * (1 / RECOVERY_RATE) -- new strain-s
+          infections per current strain-s infected per step,
+          multiplied by the expected infectious period in steps.
+          Rolling-mean smoothed with the row's window.
+        * expected R(t, s) = expected_R_per_step(s, t) *
+          (1 / RECOVERY_RATE), where the per-step quantity is the
           population-average probability that strain s infects a
           randomly-sampled individual on a single contact in one step
-          (logged per step as `strain_df["theoretical_R"]`, with
-          infected hosts contributing 0). Plotted unsmoothed since it
-          is already a smooth function of population state.
+          (logged per step as `strain_df["expected_R"]`, with
+          currently-infected hosts contributing 0 since they cannot
+          be re-infected). Plotted unsmoothed since it is already a
+          smooth function of population state.
 
         Strains are color-coded by Hamming weight (hue) with
         lightness disambiguating strains of the same weight. The
@@ -1386,26 +1397,26 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
 
         prev_per_strain = np.zeros((T, n_strains), dtype=float)
         new_inf_per_strain = np.zeros((T, n_strains), dtype=float)
-        theo_R_per_strain = np.zeros((T, n_strains), dtype=float)
+        expected_R_per_strain = np.zeros((T, n_strains), dtype=float)
 
         for _, row in strain_df.iterrows():
             i = step_to_idx[row["Step"]]
             s = int(row["strain"])
             prev_per_strain[i, s] = float(row["count"])
             new_inf_per_strain[i, s] = float(row.get("new_infections", 0.0))
-            theo_R_per_strain[i, s] = float(row.get("theoretical_R", 0.0))
+            expected_R_per_strain[i, s] = float(row.get("expected_R", 0.0))
 
         # Convert per-step rates to per-infectious-period totals.
         infectious_period = 1.0 / RECOVERY_RATE
-        theo_R_per_strain = theo_R_per_strain * infectious_period
+        expected_R_per_strain = expected_R_per_strain * infectious_period
 
         with np.errstate(divide="ignore", invalid="ignore"):
-            r_actual_per_strain = np.where(
+            r_empirical_per_strain = np.where(
                 prev_per_strain > 0,
                 new_inf_per_strain / prev_per_strain,
                 np.nan,
             )
-        r_actual_per_strain = r_actual_per_strain * infectious_period
+        r_empirical_per_strain = r_empirical_per_strain * infectious_period
 
         palette_colors = strain_palette(N_SITES, base_palette=palette)
 
@@ -1426,26 +1437,28 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
             teeplot_show=True,
             teeplot_subdir=pathlib.Path(__file__).stem,
         ) as (fig, axes):
-            ax_theo = axes[0]
-            actual_axes = axes[1:]
+            ax_expected = axes[0]
+            empirical_axes = axes[1:]
 
             for s in range(n_strains):
                 color = palette_colors[s]
                 label = f"{s:0{N_SITES}b}"
-                ax_theo.plot(
+                ax_expected.plot(
                     unique_steps,
-                    theo_R_per_strain[:, s],
+                    expected_R_per_strain[:, s],
                     color=color,
                     linestyle="--",
                     linewidth=1.5,
                     label=label,
                 )
-            ax_theo.axhline(1.0, color="gray", linestyle=":", linewidth=0.8)
-            ax_theo.set_ylabel("theoretical R\n(R0-like)")
-            ax_theo.set_ylim(bottom=0.0)
-            sns.despine(ax=ax_theo)
+            ax_expected.axhline(
+                1.0, color="gray", linestyle=":", linewidth=0.8
+            )
+            ax_expected.set_ylabel("expected R")
+            ax_expected.set_ylim(bottom=0.0)
+            sns.despine(ax=ax_expected)
 
-            ax_theo.legend(
+            ax_expected.legend(
                 title="strain",
                 loc="center left",
                 bbox_to_anchor=(1.02, 0.5),
@@ -1454,37 +1467,29 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
                 ncol=1 if n_strains <= 8 else 2,
                 fontsize=8,
             )
-            ax_theo.set_title(
-                "per-strain reproduction number "
-                "(scaled to per-infectious-period)",
-                fontsize=10,
-            )
 
-            for ax, w in zip(actual_axes, windows):
+            for ax, w in zip(empirical_axes, windows):
                 for s in range(n_strains):
                     color = palette_colors[s]
-                    actual = pd.Series(r_actual_per_strain[:, s])
+                    empirical = pd.Series(r_empirical_per_strain[:, s])
                     if w > 1:
-                        actual = actual.rolling(
+                        empirical = empirical.rolling(
                             window=w,
                             min_periods=max(1, w // 4),
                             center=True,
                         ).mean()
                     ax.plot(
                         unique_steps,
-                        actual.to_numpy(),
+                        empirical.to_numpy(),
                         color=color,
                         linestyle="-",
                         linewidth=1.2,
                     )
                 ax.axhline(1.0, color="gray", linestyle=":", linewidth=0.8)
-                window_label = (
-                    "unsmoothed" if w == 1 else f"rolling mean, window={w}"
-                )
-                ax.set_ylabel(f"actual R\n({window_label})")
+                ax.set_ylabel(f"empirical R\nrolling window = {w}")
                 sns.despine(ax=ax)
 
-            actual_axes[-1].set_xlabel("Time")
+            empirical_axes[-1].set_xlabel("Time")
 
     return (make_r_curves_plot,)
 

--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -140,32 +140,35 @@ def delimit_simulation(mo):
     individual strain (the strain count is `2**N_SITES`, capped here
     at 16). In addition to the phylogeny-and-strain-network plots
     inherited from the 32-site notebook, this notebook renders an
-    "r-curves" figure: a multi-row stack (one row per smoothing
-    window, unsmoothed at the top) plotting both *actual* and
-    *theoretical* per-strain reproduction numbers, defined per step
-    (rather than per infectious period) so that they can be compared
-    apples-to-apples against directly-observed transmission events:
+    "r-curves" figure: a multi-row stack with the *theoretical* per-
+    strain reproduction number on the very top row by itself, and
+    the *actual* per-strain reproduction number on subsequent rows
+    at increasing smoothing windows (unsmoothed first). Both are
+    scaled by the expected infectious period `1 / RECOVERY_RATE` so
+    the plotted values are total expected new infections per
+    infected over an infection (i.e. an `R0`-like quantity) rather
+    than the per-step rate, and `R = 1` is drawn as the
+    epidemic-threshold reference line.
 
-    * `R_actual(t, s) = new_infections(s, t) / n_with_strain(s, t)` --
-      the number of new strain-`s` infections caused per current
-      strain-`s` infected per step, computed from instrumentation
+    * `R_actual(t, s) = new_infections(s, t) / n_with_strain(s, t) /
+      RECOVERY_RATE` -- the number of new strain-`s` infections
+      caused per current strain-`s` infected per step, multiplied by
+      the expected infectious period, computed from instrumentation
       logged inside `simulate()`. `new_infections` is captured
       pre-mutation in `update_simulation()` so the strain label
       reflects the strain that actually transmitted, not its
       post-mutation descendant.
 
-    * `R_theo(t, s)` -- the average over the population of the
-      probability that strain `s` infects a randomly-sampled
+    * `R_theo(t, s) = R_theo_per_step(s, t) / RECOVERY_RATE`, where
+      `R_theo_per_step(s, t)` is the average over the population of
+      the probability that strain `s` infects a randomly-sampled
       individual on a single contact in one step (infected hosts
-      contribute zero since they cannot be re-infected), so
-      `R_theo(s, t) * n_with_strain(s, t)` is the expected number of
-      new strain-`s` infections per step. This is logged per step as
-      `strain_df["theoretical_R"]` alongside `count` and
-      `new_infections`.
-
-    Both are plotted as line curves color-coded by strain; actual is
-    rolling-mean smoothed with the row's window, theoretical is left
-    unsmoothed (it is already a smooth function of population state).
+      contribute zero since they cannot be re-infected). The per-
+      step quantity is logged as `strain_df["theoretical_R"]`
+      alongside `count` and `new_infections`; multiplying by the
+      expected infectious period gives the analog of `R0` (so
+      `R_theo(s, t) * n_with_strain(s, t) * RECOVERY_RATE` is the
+      expected number of new strain-`s` infections per step).
 
     Phylogeny estimation still uses *hereditary stratigraphic surface*
     annotations (see https://hstrat.rtfd.io). Each infected host carries
@@ -1342,30 +1345,36 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
     def make_r_curves_plot(
         N_SITES: int,
         strain_df,
+        RECOVERY_RATE: float,
         smoothing_windows=(1, 5, 25, 125),
         palette: str = "husl",
         teeplot_outattrs: dict = {},
     ) -> None:
-        """Multi-row figure of per-strain reproduction number, one row
-        per smoothing window (unsmoothed at the top). In each row,
-        actual R(t, s) = new_infections(s, t) / n_with_strain(s, t)
-        (solid; computed directly from the per-step instrumentation
-        logged in `strain_df`: `new_infections` is the population
-        fraction newly infected with strain s in the step, captured
-        pre-mutation, and `count` is the population fraction currently
-        infected with strain s) is overlaid with theoretical R(t, s)
-        (dashed; logged per step as `theoretical_R`, equal to the
-        average over the population of P(strain s infects a randomly-
-        sampled individual on a single contact in one step), with
-        infected hosts contributing 0 since they cannot be re-infected
-        --- so theoretical_R(s, t) * n_with_strain(s, t) is the
-        expected number of new strain-s infections per step). The
-        actual R is rolling-mean smoothed with the row's window;
-        theoretical R is plotted unsmoothed (it is already a smooth
-        function of population state). Strains are color-coded by
-        Hamming weight (hue) with lightness disambiguating strains of
-        the same weight. The first row's window is always 1 (no
-        smoothing).
+        """Multi-row figure of per-strain reproduction number. The
+        first row plots the *theoretical* R per strain on its own,
+        and each subsequent row plots the *actual* R per strain at a
+        different smoothing window (unsmoothed first). Both are
+        scaled by the expected infectious period `1 / RECOVERY_RATE`
+        so the plotted values are total expected new infections per
+        infected over an infection (an `R0`-like quantity), not the
+        per-step rate.
+
+        * actual R(t, s) = (new_infections(s, t) / n_with_strain(s, t))
+          * (1 / RECOVERY_RATE) -- new strain-s infections per current
+          strain-s infected per step, multiplied by the expected
+          infectious period in steps. Rolling-mean smoothed with the
+          row's window.
+        * theoretical R(t, s) = theoretical_R_per_step(s, t) *
+          (1 / RECOVERY_RATE) where the per-step quantity is the
+          population-average probability that strain s infects a
+          randomly-sampled individual on a single contact in one step
+          (logged per step as `strain_df["theoretical_R"]`, with
+          infected hosts contributing 0). Plotted unsmoothed since it
+          is already a smooth function of population state.
+
+        Strains are color-coded by Hamming weight (hue) with
+        lightness disambiguating strains of the same weight. The
+        epidemic threshold R = 1 is drawn as a dotted reference line.
         """
         n_strains = 1 << N_SITES
 
@@ -1386,12 +1395,17 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
             new_inf_per_strain[i, s] = float(row.get("new_infections", 0.0))
             theo_R_per_strain[i, s] = float(row.get("theoretical_R", 0.0))
 
+        # Convert per-step rates to per-infectious-period totals.
+        infectious_period = 1.0 / RECOVERY_RATE
+        theo_R_per_strain = theo_R_per_strain * infectious_period
+
         with np.errstate(divide="ignore", invalid="ignore"):
             r_actual_per_strain = np.where(
                 prev_per_strain > 0,
                 new_inf_per_strain / prev_per_strain,
                 np.nan,
             )
+        r_actual_per_strain = r_actual_per_strain * infectious_period
 
         palette_colors = strain_palette(N_SITES, base_palette=palette)
 
@@ -1399,24 +1413,56 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
         if not windows or windows[0] != 1:
             windows = [1] + windows
 
+        n_rows = 1 + len(windows)
+
         with tp.teed(
             plt.subplots,
-            nrows=len(windows),
+            nrows=n_rows,
             ncols=1,
-            figsize=(8, 2.0 * len(windows) + 1.0),
+            figsize=(8, 2.0 * n_rows + 1.0),
             sharex=True,
             gridspec_kw={"hspace": 0.08},
             teeplot_outattrs=teeplot_outattrs,
             teeplot_show=True,
             teeplot_subdir=pathlib.Path(__file__).stem,
         ) as (fig, axes):
-            if len(windows) == 1:
-                axes = [axes]
+            ax_theo = axes[0]
+            actual_axes = axes[1:]
 
-            for ax, w in zip(axes, windows):
+            for s in range(n_strains):
+                color = palette_colors[s]
+                label = f"{s:0{N_SITES}b}"
+                ax_theo.plot(
+                    unique_steps,
+                    theo_R_per_strain[:, s],
+                    color=color,
+                    linestyle="--",
+                    linewidth=1.5,
+                    label=label,
+                )
+            ax_theo.axhline(1.0, color="gray", linestyle=":", linewidth=0.8)
+            ax_theo.set_ylabel("theoretical R\n(R0-like)")
+            ax_theo.set_ylim(bottom=0.0)
+            sns.despine(ax=ax_theo)
+
+            ax_theo.legend(
+                title="strain",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1 if n_strains <= 8 else 2,
+                fontsize=8,
+            )
+            ax_theo.set_title(
+                "per-strain reproduction number "
+                "(scaled to per-infectious-period)",
+                fontsize=10,
+            )
+
+            for ax, w in zip(actual_axes, windows):
                 for s in range(n_strains):
                     color = palette_colors[s]
-                    label = f"{s:0{N_SITES}b}"
                     actual = pd.Series(r_actual_per_strain[:, s])
                     if w > 1:
                         actual = actual.rolling(
@@ -1430,37 +1476,15 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
                         color=color,
                         linestyle="-",
                         linewidth=1.2,
-                        label=label,
                     )
-                    ax.plot(
-                        unique_steps,
-                        theo_R_per_strain[:, s],
-                        color=color,
-                        linestyle="--",
-                        linewidth=1.2,
-                    )
-                ax.axhline(0.0, color="gray", linestyle=":", linewidth=0.8)
+                ax.axhline(1.0, color="gray", linestyle=":", linewidth=0.8)
                 window_label = (
                     "unsmoothed" if w == 1 else f"rolling mean, window={w}"
                 )
-                ax.set_ylabel(f"R per step\n({window_label})")
+                ax.set_ylabel(f"actual R\n({window_label})")
                 sns.despine(ax=ax)
 
-            axes[-1].set_xlabel("Time")
-            axes[0].legend(
-                title="strain",
-                loc="center left",
-                bbox_to_anchor=(1.02, 0.5),
-                frameon=False,
-                handletextpad=0.4,
-                ncol=1 if n_strains <= 8 else 2,
-                fontsize=8,
-            )
-            axes[0].set_title(
-                "actual (solid) vs. theoretical (dashed) "
-                "per-strain new infections per current infected per step",
-                fontsize=10,
-            )
+            actual_axes[-1].set_xlabel("Time")
 
     return (make_r_curves_plot,)
 
@@ -1591,6 +1615,7 @@ def run_phylogeny_sweep(
                     make_r_curves_plot(
                         PHYLO_N_SITES,
                         _strain_df,
+                        RECOVERY_RATE=RECOVERY_RATE_,
                         palette=palette,
                         teeplot_outattrs={
                             "a": "r-curves",

--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -1,0 +1,1646 @@
+import marimo
+
+__generated_with = "0.23.2"
+app = marimo.App(width="full")
+
+
+@app.cell
+def import_std():
+    import gc
+    import pathlib
+    import random
+    from typing import Dict, List, Sequence, Tuple, Union
+    import uuid
+
+    return Dict, List, Sequence, Tuple, Union, gc, pathlib, random, uuid
+
+
+@app.cell
+def import_pkg():
+    try:
+        import cupy as cp
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "cupy import failed; falling back to numpy "
+            "(GPU engine unavailable)",
+            stacklevel=2,
+        )
+        import numpy as cp
+
+    # workaround: iplotx 1.7.x uses importlib.metadata without importing it
+    import importlib.metadata  # noqa: F401
+
+    import downstream.dstream as dstream
+    import hstrat
+    import igraph as ig
+    import iplotx
+    import marimo as mo
+    import matplotlib.pyplot as plt
+    from matplotlib.ticker import FuncFormatter, MaxNLocator
+    import numpy as np
+    import pandas as pd
+    from phyloframe import legacy as pfl
+    import polars as pl
+    import seaborn as sns
+    from teeplot import teeplot as tp
+    from tqdm.auto import tqdm
+    from watermark import watermark
+
+    from pylib import allele_palette, draw_scatter_tree, strain_palette
+
+    return (
+        FuncFormatter,
+        MaxNLocator,
+        allele_palette,
+        cp,
+        draw_scatter_tree,
+        dstream,
+        hstrat,
+        ig,
+        iplotx,
+        mo,
+        np,
+        pd,
+        pfl,
+        pl,
+        plt,
+        sns,
+        strain_palette,
+        tp,
+        tqdm,
+        watermark,
+    )
+
+
+@app.cell(hide_code=True)
+def do_watermark(mo, watermark):
+    mo.md(
+        f"""
+    ```Text
+    {watermark(
+        current_date=True,
+        iso8601=True,
+        machine=True,
+        updated=True,
+        python=True,
+        iversions=True,
+        globals_=globals(),
+    )}
+    ```
+    """
+    )
+    return
+
+
+@app.cell
+def configure_args(mo):
+    # Marimo CLI args (set via `marimo edit notebook.py -- --pop-size N ...`
+    # or `marimo export ipynb ... -- --pop-size N ...`). Defaults match the
+    # current sweep settings: POP_SIZE=200_000 hosts and N_STEPS=100 steps.
+    _args = mo.cli_args()
+    POP_SIZE = int(_args.get("pop-size") or 100_000)
+    POW = float(_args.get("pow") or 1.0)
+    N_STEPS = int(_args.get("n-steps") or 1_200)
+    N_REPLICATES = int(_args.get("n-replicates") or 1)
+    ENGINE = str(_args.get("engine") or "numpy").lower()
+    if ENGINE not in ("numpy", "cupy"):
+        raise ValueError(
+            f"engine must be 'numpy' or 'cupy', got {ENGINE!r}",
+        )
+    SKIP_PLOTTING = bool(_args.get("skip-plotting") or False)
+    print(
+        f"args: POP_SIZE={POP_SIZE} N_STEPS={N_STEPS} "
+        f"N_REPLICATES={N_REPLICATES} ENGINE={ENGINE} "
+        f"SKIP_PLOTTING={SKIP_PLOTTING}",
+    )
+    return ENGINE, N_REPLICATES, N_STEPS, POP_SIZE, POW, SKIP_PLOTTING
+
+
+@app.cell
+def configure_backend(ENGINE, cp, np):
+    use_cupy = (
+        ENGINE == "cupy"
+    )  # use cupy backend (GPU), otherwise numpy (CPU)
+    xp = [np, cp][use_cupy]
+    return (xp,)
+
+
+@app.cell(hide_code=True)
+def delimit_simulation(mo):
+    mo.md(
+        """
+    ## Simulation Implementation
+
+    This notebook is an R-per-strain companion to
+    `2026-05-03-allele-abm-strain-curves.py`: the sweep is restricted
+    to `N_SITES = 2, 3, 4` so that per-strain prevalence and
+    per-strain population-average susceptibility can be tracked by
+    individual strain (the strain count is `2**N_SITES`, capped here
+    at 16). In addition to the phylogeny-and-strain-network plots
+    inherited from the 32-site notebook, this notebook renders an
+    "r-curves" figure: two vertically-stacked panels sharing the
+    time axis, with the *theoretical* per-strain reproduction number
+    `R_theo(t, s) = (CONTACT_RATE / RECOVERY_RATE) * S_s(t)` (dashed,
+    using the product of per-allele susceptibilities as the strain
+    susceptibility proxy) on top, and the *actual* per-strain
+    reproduction number `R_actual(t, s) = 1 + (1/RECOVERY_RATE) *
+    d ln(I_s)/dt` (solid, derived from the prevalence trajectory via
+    centered finite differences on log-prevalence) on bottom, color-
+    coded by strain. `R = 1` is the epidemic threshold: strains above
+    are growing, strains below are shrinking.
+
+    Phylogeny estimation still uses *hereditary stratigraphic surface*
+    annotations (see https://hstrat.rtfd.io). Each infected host carries
+    a `dstream_S=64`-site, 1-bit "hybrid" surface; the donor surface
+    state is copied to the recipient on transmission (the ABM analogue
+    of `CloneDescendant`). Per-step Hamming-weight prevalence and
+    per-strain prevalence are both logged as long-form dataframes (one
+    row per `(Step, hw)` and `(Step, strain)`).
+
+    The vectorized deposit pattern is adapted from
+    https://github.com/mmore500/hstrat-synthesis (see `pylib/track_ca.py`).
+    """
+    )
+    return
+
+
+@app.cell
+def def_simulate(
+    Dict,
+    List,
+    Sequence,
+    Tuple,
+    Union,
+    dstream,
+    gc,
+    np,
+    pd,
+    random,
+    tqdm,
+    xp,
+):
+    def simulate(
+        N_SITES: int = 2,
+        POP_SIZE: int = 1_000_000,
+        CONTACT_RATE: float = 0.3,
+        RECOVERY_RATE: float = 0.1,
+        MUTATION_RATE: Union[float, Sequence[float]] = 1e-4,
+        WANING_RATE: float = 0.02,
+        IMMUNE_STRENGTH: float = 0.9,
+        N_STEPS: int = 1_000,
+        SEED_COUNT: int = 10,
+        within_host_b: float = 0.2,
+        within_host_t: float = 25.0,
+        seed: int = 1,
+        MUTATOR_HOSTS_N: int = 0,
+        MUTATOR_HOSTS_MX: float = 1.0,
+        MUTATION_THRESHOLD: float = 0.0,
+        IMMUNITY_CEILING: float = 1.0,
+        IMMUNITY_FLOOR: float = 0.0,
+        track_phylogeny: bool = False,
+        DSTREAM_S: int = 64,
+        DSTREAM_ALGO=None,
+        N_SAMPLE: int = 2000,
+        pow: float = 1.0,
+    ) -> Union[
+        Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame],
+        Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame],
+    ]:
+        random.seed(seed)
+        np.random.seed(seed)
+        xp.random.seed(seed)
+
+        if DSTREAM_ALGO is None:
+            DSTREAM_ALGO = dstream.hybrid_0_steady_1_tilted_2_algo
+
+        MUTATION_RATE = xp.asarray(MUTATION_RATE, dtype=xp.float32)
+
+        # Pick the smallest unsigned int dtype that holds `N_SITES` bits.
+        # 16/32/64-site sweeps round-trip through uint16/uint32/uint64
+        # without truncation; >64 would need a custom multi-word genome.
+        if N_SITES > 64:
+            raise NotImplementedError(
+                "current data types support only up to 64 sites",
+            )
+        elif N_SITES > 32:
+            genome_dtype = xp.uint64
+        elif N_SITES > 16:
+            genome_dtype = xp.uint32
+        else:
+            genome_dtype = xp.uint16
+
+        def initialize_pop() -> (
+            Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]
+        ):
+            """Initialize population statuses, genomes, and immune history."""
+            pathogen_genomes = xp.zeros(shape=POP_SIZE, dtype=genome_dtype)
+            host_immunities = xp.full(
+                shape=(POP_SIZE, 2 * N_SITES),
+                fill_value=0.0,
+                dtype=xp.float32,
+            )
+            host_statuses = xp.full(
+                shape=POP_SIZE, fill_value=0, dtype=xp.uint8
+            )
+            pathogen_markers = xp.random.randint(
+                low=0,
+                high=2**63,
+                size=POP_SIZE,
+                dtype=xp.int64,
+            ).astype(xp.uint64)
+            pathogen_markers |= xp.random.randint(
+                low=0,
+                high=2,
+                size=POP_SIZE,
+                dtype=xp.uint64,
+            ) << xp.uint64(63)
+            return (
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+            )
+
+        def infect_initial(
+            host_statuses: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+        ) -> Tuple[xp.ndarray, xp.ndarray]:
+            """Seed the initial infection wave with the starting strain."""
+            seeded_indices = xp.random.choice(
+                POP_SIZE, size=SEED_COUNT, replace=False
+            )
+            host_statuses[seeded_indices] = 1
+            pathogen_genomes[seeded_indices] = 0  # wildtype
+            return host_statuses, pathogen_genomes
+
+        def calc_infection_probabilities(
+            host_immunities: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+        ) -> xp.ndarray:
+            host_susceptibilities = xp.reshape(
+                1.0 - (IMMUNE_STRENGTH * host_immunities),
+                (POP_SIZE, 2 * N_SITES),
+            )
+
+            pathogen_bits = (
+                pathogen_genomes[:, None] >> xp.arange(N_SITES, dtype=xp.uint8)
+            ) & 1
+            pathogen_alleles = (
+                pathogen_bits[:, :, None] == xp.array([0, 1])
+            ).reshape(-1, 2 * N_SITES)
+
+            active_susc = xp.where(
+                pathogen_alleles, host_susceptibilities, 1.0
+            )
+            res = xp.prod(active_susc, axis=1)
+            assert res.shape == (POP_SIZE,)
+            return xp.pow(res, pow)
+
+        if MUTATION_RATE.size == 1:
+
+            def calc_mutation_probabilities(
+                host_immunities: xp.ndarray,
+                pathogen_genomes: xp.ndarray,
+            ) -> xp.ndarray:
+                pathogen_bits = (
+                    pathogen_genomes[:, None]
+                    >> xp.arange(N_SITES, dtype=xp.uint8)
+                ) & 1
+
+                imm_reshaped = xp.reshape(host_immunities, (-1, N_SITES, 2))
+
+                idx_curr = pathogen_bits[:, :, None]
+                idx_opp = 1 - idx_curr
+
+                imm_curr = xp.take_along_axis(
+                    imm_reshaped, idx_curr, axis=2
+                ).squeeze(axis=2)
+                imm_opp = xp.take_along_axis(
+                    imm_reshaped, idx_opp, axis=2
+                ).squeeze(axis=2)
+
+                host_immunity_deltas = imm_curr - imm_opp
+
+                b_values = 1.0 + within_host_b * host_immunity_deltas
+                b_values = xp.where(
+                    xp.abs(b_values - 1.0) < 1e-7, 1.000001, b_values
+                )
+
+                return (MUTATION_RATE / (b_values - 1.0)) * (
+                    xp.exp((b_values - 1.0) * within_host_t) - 1.0
+                )
+
+        else:
+
+            def calc_mutation_probabilities(
+                host_immunities: xp.ndarray,
+                pathogen_genomes: xp.ndarray,
+            ) -> xp.ndarray:
+                n_infected = host_immunities.shape[0]
+                return (
+                    xp.ones((n_infected, 1), dtype=MUTATION_RATE.dtype)
+                    * MUTATION_RATE
+                )
+
+        def update_waning(host_immunities: xp.ndarray) -> xp.ndarray:
+            host_immunities *= 1.0 - WANING_RATE
+            host_immunities[host_immunities > 0] = xp.clip(
+                host_immunities[host_immunities > 0],
+                IMMUNITY_FLOOR,
+                IMMUNITY_CEILING,
+            )
+            return host_immunities
+
+        def update_recoveries(
+            host_statuses: xp.ndarray,
+            host_immunities: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+        ) -> Tuple[xp.ndarray, xp.ndarray]:
+            recovered_mask = (host_statuses >= 1) * xp.random.rand(
+                POP_SIZE
+            ) > 1 - RECOVERY_RATE
+
+            pathogen_bits = (
+                pathogen_genomes[:, None] >> xp.arange(N_SITES, dtype=xp.uint8)
+            ) & 1
+            pathogen_alleles = (
+                pathogen_bits[:, :, None] == xp.array([0, 1])
+            ).reshape(-1, 2 * N_SITES)
+
+            assert np.all(
+                pathogen_alleles[recovered_mask].sum(axis=1) == N_SITES
+            )
+
+            host_immunities[
+                pathogen_alleles.astype(bool) & recovered_mask[:, None]
+            ] = 1.0
+
+            host_statuses += (host_statuses > 0).astype(xp.uint8)
+            host_statuses[recovered_mask] = 0
+
+            return host_statuses, host_immunities
+
+        def transmit_infection(
+            host_statuses: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+            host_immunities: xp.ndarray,
+            pathogen_markers: xp.ndarray,
+        ) -> Tuple[xp.ndarray, xp.ndarray, xp.ndarray]:
+            contacts = xp.random.randint(
+                low=0, high=POP_SIZE, size=POP_SIZE, dtype=xp.uint32
+            )
+            inf_probs = (
+                calc_infection_probabilities(
+                    host_immunities, pathogen_genomes[contacts]
+                )
+                * (host_statuses == 0)
+                * (host_statuses[contacts] > 0)
+                * CONTACT_RATE
+            )
+
+            new_infections = xp.random.rand(POP_SIZE) < inf_probs
+            host_statuses[new_infections] = 1
+            pathogen_genomes[new_infections] = pathogen_genomes[contacts][
+                new_infections
+            ]
+            pathogen_markers[new_infections] = pathogen_markers[contacts][
+                new_infections
+            ]
+
+            return host_statuses, pathogen_genomes, pathogen_markers
+
+        def apply_mutations(
+            pathogen_genomes: xp.ndarray,
+            host_statuses: xp.ndarray,
+        ) -> xp.ndarray:
+            mutation_mask = (host_statuses == 1).astype(bool)
+
+            mprobs = calc_mutation_probabilities(
+                host_immunities[mutation_mask],
+                pathogen_genomes[mutation_mask],
+            )
+            mutator_n = host_statuses[:MUTATOR_HOSTS_N].sum()
+            mprobs[:mutator_n] = xp.minimum(
+                mprobs[:mutator_n] * MUTATOR_HOSTS_MX, 1.0
+            )
+
+            mprobs[mprobs < MUTATION_THRESHOLD] = 0.0
+
+            for s in range(N_SITES):
+                mutation_occurs = (
+                    xp.random.rand(mprobs.shape[0]) < mprobs[:, s]
+                ).astype(genome_dtype)
+                pathogen_genomes[mutation_mask] ^= (
+                    mutation_occurs << s
+                ).astype(genome_dtype)
+
+            return pathogen_genomes
+
+        def deposit_strata(
+            pathogen_markers: xp.ndarray,
+            t: int,
+        ) -> xp.ndarray:
+            site = DSTREAM_ALGO.assign_storage_site(DSTREAM_S, t + DSTREAM_S)
+            if site is None:
+                return pathogen_markers
+            new_bits = xp.random.randint(
+                0,
+                2,
+                size=POP_SIZE,
+                dtype=xp.uint64,
+            )
+            pathogen_markers ^= new_bits << np.uint64(63 - site)
+            return pathogen_markers
+
+        def update_simulation(
+            host_statuses: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+            host_immunities: xp.ndarray,
+            pathogen_markers: xp.ndarray,
+            t: int,
+        ) -> Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]:
+            (
+                host_statuses,
+                pathogen_genomes,
+                pathogen_markers,
+            ) = transmit_infection(
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+            )
+            pathogen_genomes = apply_mutations(pathogen_genomes, host_statuses)
+            host_statuses, host_immunities = update_recoveries(
+                host_statuses, host_immunities, pathogen_genomes
+            )
+            host_immunities = update_waning(host_immunities)
+            pathogen_markers = deposit_strata(pathogen_markers, t)
+
+            return (
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+            )
+
+        (
+            host_statuses,
+            pathogen_genomes,
+            host_immunities,
+            pathogen_markers,
+        ) = initialize_pop()
+        host_statuses, pathogen_genomes = infect_initial(
+            host_statuses, pathogen_genomes
+        )
+        data_log: List[Dict[str, float]] = []
+        hw_log: List[Dict[str, float]] = []
+        strain_log: List[Dict[str, float]] = []
+        n_strains = 1 << N_SITES
+
+        for t in tqdm(range(N_STEPS), mininterval=20.0):
+            (
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+            ) = update_simulation(
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+                t,
+            )
+
+            inf_mask = host_statuses > 0
+            hw_prevalences: List[float] = [0.0] * (N_SITES + 1)
+            strain_prevalences: List[float] = [0.0] * n_strains
+
+            if xp.any(inf_mask):
+                infected_bits = (
+                    pathogen_genomes[inf_mask, None]
+                    >> xp.arange(N_SITES, dtype=xp.uint8)
+                ) & 1
+                hw_per_host = infected_bits.sum(axis=1).astype(xp.int64)
+                hw_counts_arr = xp.bincount(hw_per_host, minlength=N_SITES + 1)
+                hw_prevalences = [
+                    float(c) / POP_SIZE for c in hw_counts_arr.tolist()
+                ]
+
+                strain_per_host = pathogen_genomes[inf_mask].astype(xp.int64)
+                strain_counts_arr = xp.bincount(
+                    strain_per_host, minlength=n_strains
+                )
+                strain_prevalences = [
+                    float(c) / POP_SIZE for c in strain_counts_arr.tolist()
+                ]
+
+            for w, count in enumerate(hw_prevalences):
+                hw_log.append(
+                    {
+                        "Step": t,
+                        "Seed": seed,
+                        "hw": w,
+                        "count": count,
+                    }
+                )
+
+            for s, count in enumerate(strain_prevalences):
+                strain_log.append(
+                    {
+                        "Step": t,
+                        "Seed": seed,
+                        "strain": s,
+                        "count": count,
+                    }
+                )
+
+            avg_susc = xp.mean(
+                (1.0 - (IMMUNE_STRENGTH * host_immunities))
+                * (host_statuses == 0)[:, None],
+                axis=0,
+            )
+
+            immunity_dict = {}
+            for i in range(2 * N_SITES):
+                site = i // 2
+                bit = i % 2
+                immunity_dict[f"Susc_S{site}_B{bit}"] = float(avg_susc[i])
+
+            log_entry = {
+                "Step": t,
+                "Seed": seed,
+                "Total_Infected": float(xp.sum(inf_mask)) / POP_SIZE,
+            }
+            log_entry.update(immunity_dict)
+            data_log.append(log_entry)
+
+        df = pd.DataFrame(data_log).fillna(0).copy()
+        hw_df = pd.DataFrame(hw_log)
+        strain_df = pd.DataFrame(strain_log)
+        if not track_phylogeny:
+            return df, hw_df, strain_df
+
+        algo_name = f"dstream.{DSTREAM_ALGO.__name__}"
+        S = DSTREAM_S
+        T_bitwidth = 32
+        bitwidth = 1
+        bytes_per_T = T_bitwidth // 8
+        bytes_per_storage = S * bitwidth // 8
+        bytes_per_row = bytes_per_T + bytes_per_storage
+        empty_records = pd.DataFrame(
+            {
+                "data_hex": pd.Series([], dtype=str),
+                "dstream_algo": pd.Series([], dtype=str),
+                "dstream_storage_bitoffset": pd.Series([], dtype="int64"),
+                "dstream_storage_bitwidth": pd.Series([], dtype="int64"),
+                "dstream_T_bitoffset": pd.Series([], dtype="int64"),
+                "dstream_T_bitwidth": pd.Series([], dtype="int64"),
+                "dstream_S": pd.Series([], dtype="int64"),
+                "extant": pd.Series([], dtype=bool),
+                "snapshot_step": pd.Series([], dtype="int64"),
+                "genome": pd.Series([], dtype="int64"),
+                "taxon_id": pd.Series([], dtype="int64"),
+            },
+        )
+        infected_idx = xp.where(host_statuses > 0)[0]
+        n_inf = int(infected_idx.size)
+        if n_inf == 0:
+            return df, hw_df, strain_df, empty_records
+
+        n_sample = min(N_SAMPLE, n_inf)
+        sampled = (
+            xp.random.choice(infected_idx, size=n_sample, replace=False)
+            if n_sample < n_inf
+            else infected_idx
+        )
+
+        # CUPY SUPPORT: Transfer to host if using GPU
+        _to_np = (lambda a: np.asarray(a)) if xp is np else (lambda a: a.get())
+        sampled_markers = _to_np(pathogen_markers[sampled])
+        sampled_genomes = _to_np(pathogen_genomes[sampled])
+        # Rank includes implicit predeposits
+        sampled_steps = np.full(n_sample, N_STEPS + DSTREAM_S, dtype=np.uint32)
+        sampled_taxon_ids = np.arange(n_sample, dtype=np.int64)
+
+        T_bytes_hex = sampled_steps.astype(">u4").tobytes().hex()
+        marker_bytes_hex = sampled_markers.astype(">u8").tobytes().hex()
+        data_hex = [
+            (
+                T_bytes_hex[i * bytes_per_T * 2 : (i + 1) * bytes_per_T * 2]
+                + marker_bytes_hex[
+                    i * bytes_per_storage * 2 : (i + 1) * bytes_per_storage * 2
+                ]
+            )
+            for i in range(n_sample)
+        ]
+
+        records_df = pd.DataFrame(
+            {
+                "data_hex": data_hex,
+                "dstream_algo": algo_name,
+                "dstream_storage_bitoffset": bytes_per_T * 8,
+                "dstream_storage_bitwidth": bytes_per_storage * 8,
+                "dstream_T_bitoffset": 0,
+                "dstream_T_bitwidth": T_bitwidth,
+                "dstream_S": S,
+                "extant": True,
+                "snapshot_step": sampled_steps.astype(np.int64),
+                "genome": sampled_genomes.astype(np.int64),
+                "taxon_id": sampled_taxon_ids,
+            }
+        )
+        assert all(len(h) == bytes_per_row * 2 for h in data_hex), (
+            f"hex length mismatch (expected {bytes_per_row * 2}, "
+            f"got {set(len(h) for h in data_hex)})"
+        )
+        del data_hex, T_bytes_hex, marker_bytes_hex
+        gc.collect()
+        return df, hw_df, strain_df, records_df
+
+    return (simulate,)
+
+
+@app.cell(hide_code=True)
+def delimit_reconstruct(mo):
+    mo.md(
+        """
+    ## Surface-Annotation Reconstruction
+
+    Given the snapshot records emitted by `simulate(..., track_phylogeny=
+    True)`, run `hstrat.dataframe.surface_unpack_reconstruct` followed by
+    `hstrat.dataframe.surface_postprocess_trie` to estimate the phylogenetic
+    tree. We use `AssignOriginTimeNodeRankTriePostprocessor(t0="dstream_S")`
+    so that origin times line up with simulation step numbers.
+    """
+    )
+    return
+
+
+@app.cell
+def def_reconstruct_phylogeny(gc, hstrat, pd, pl):
+    def reconstruct_phylogeny(
+        records_df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        in_df = pl.from_pandas(records_df)
+        post = hstrat.dataframe.surface_build_tree(
+            in_df,
+            trie_postprocessor=(
+                hstrat.phylogenetic_inference.AssignOriginTimeNodeRankTriePostprocessor(
+                    t0="dstream_S",
+                )
+            ),
+        ).to_pandas()
+        gc.collect()
+        for col in ("id", "ancestor_id"):
+            if col in post.columns:
+                post[col] = post[col].astype("int64")
+        post["extant"] = post["extant"].fillna(False).astype(bool)
+        for col in ("snapshot_step", "genome", "origin_time"):
+            if col in post.columns:
+                post[col] = pd.to_numeric(post[col], errors="coerce")
+        return post
+
+    return (reconstruct_phylogeny,)
+
+
+@app.cell(hide_code=True)
+def delimit_phylogeny(mo):
+    mo.md(
+        """
+    ## Surface-Reconstructed Phylogeny
+
+    Sweep `N_SITES` over a few values and render the surface-reconstructed
+    phylogeny next to the absolute-prevalence and Hamming-weight stackplots.
+    """
+    )
+    return
+
+
+@app.cell
+def def_make_phylogeny_plot(
+    FuncFormatter,
+    MaxNLocator,
+    draw_scatter_tree,
+    np,
+    pathlib,
+    pd,
+    pfl,
+    plt,
+    sns,
+    tp,
+):
+    def make_phylogeny_plot(
+        N_SITES: int,
+        phylo_df,
+        hw_df,
+        phylogeny_df,
+        max_tips: int = 10_000,
+        seed: int = 0,
+        palette: str = "rocket_r",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        pruned_df = (
+            pfl.alifestd_downsample_tips_uniform_asexual(
+                phylogeny_df,
+                n_downsample=max_tips,
+                seed=0,
+            )
+            .pipe(pfl.alifestd_add_global_root, root_attrs={"origin_time": 0})
+            .pipe(pfl.alifestd_collapse_unifurcations)
+            .pipe(pfl.alifestd_try_add_ancestor_list_col)
+            .pipe(pfl.alifestd_ladderize_asexual)
+            .pipe(pfl.alifestd_assign_contiguous_ids)
+        )
+        assert pfl.alifestd_validate(pruned_df)
+        print(f"  downsampled tree: {len(pruned_df)} nodes")
+        print(f"  leaf count: {pfl.alifestd_count_leaf_nodes(pruned_df)}")
+
+        pruned_df = pruned_df.assign(
+            hw=pruned_df["genome"].map(
+                lambda g: None if pd.isna(g) else bin(int(g)).count("1"),
+            ),
+        )
+        pruned_df = pruned_df.assign(
+            hw_label=pruned_df["hw"].map(
+                lambda w: None if pd.isna(w) else f"HW {int(w)}"
+            ),
+        )
+
+        hw_values = list(range(N_SITES + 1))
+        hw_palette = sns.color_palette(palette, len(hw_values))
+
+        present_hw = sorted(int(w) for w in hw_df["hw"].unique())
+        hw_labels = [f"HW {w}" for w in present_hw]
+        plot_df = hw_df.assign(
+            y=-hw_df["Step"],
+            hw_label=hw_df["hw"].map(lambda w: f"HW {int(w)}"),
+        )
+        plot_df = plot_df[plot_df["count"] > 0]
+
+        if len(present_hw) > 4:
+            _idx = np.unique(
+                np.linspace(0, len(present_hw) - 1, 4).round().astype(int)
+            ).tolist()
+        else:
+            _idx = list(range(len(present_hw)))
+        hw_legend_entries = [(present_hw[i], hw_labels[i]) for i in _idx]
+
+        def _hw_handle(w, label):
+            return plt.Line2D(
+                [0],
+                [0],
+                marker="s",
+                color="w",
+                markerfacecolor=hw_palette[w],
+                markersize=10,
+                label=label,
+            )
+
+        hw_palette_map = {f"HW {w}": hw_palette[w] for w in present_hw}
+
+        with tp.teed(
+            plt.subplots,
+            nrows=1,
+            ncols=3,
+            figsize=(8, 6),
+            gridspec_kw={
+                "width_ratios": [1.4, 1.0, 1.0],
+                "wspace": 0.1,
+            },
+            sharey=True,
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_tree, ax_strain, ax_hw = axes
+
+            sns.histplot(
+                data=plot_df,
+                y="y",
+                hue="hw_label",
+                hue_order=hw_labels,
+                weights="count",
+                binwidth=phylo_df["Step"].diff().min(),
+                multiple="stack",
+                stat="count",
+                element="poly",
+                palette=hw_palette_map,
+                ax=ax_strain,
+                fill=True,
+                linewidth=0,
+                legend=False,
+            )
+            _band_xs = [
+                c.get_paths()[0].vertices[:, 0].max()
+                for c in ax_strain.collections
+                if c.get_paths()
+            ]
+            if _band_xs:
+                _peak = max(_band_xs)
+                _lo, _ = ax_strain.get_xlim()
+                ax_strain.set_xlim(_lo, _peak * 1.05)
+
+            sns.kdeplot(
+                data=plot_df,
+                y="y",
+                hue="hw_label",
+                hue_order=hw_labels,
+                weights="count",
+                multiple="fill",
+                common_norm=True,
+                cut=0,
+                palette=hw_palette_map,
+                ax=ax_hw,
+                fill=True,
+                linewidth=0,
+                legend=False,
+                bw_adjust=0.5,
+            )
+
+            for ax in (ax_strain, ax_hw):
+                ax.set_xlabel("")
+            ax_hw.set_xlim(0, 1)
+
+            ax_tree.set_ylabel("step")
+            ax_tree.tick_params(left=True, labelleft=True)
+            for ax in (ax_strain, ax_hw):
+                ax.tick_params(labelleft=False, left=False)
+                ax.xaxis.tick_top()
+                ax.xaxis.set_label_position("top")
+
+            ax_tree.tick_params(bottom=False, labelbottom=False)
+            sns.despine(ax=ax_strain, left=True, bottom=True, top=False)
+            sns.despine(ax=ax_hw, left=True, bottom=True, top=False)
+
+            ax_hw.legend(
+                handles=[
+                    _hw_handle(w, label) for w, label in hw_legend_entries
+                ],
+                title="Hamming weight",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+            )
+
+            draw_scatter_tree(
+                pruned_df.reset_index(drop=True),
+                ax=ax_tree,
+                hue="hw_label",
+                scatter_kws=dict(
+                    legend=False,
+                    palette=hw_palette_map,
+                ),
+                tree_kws=dict(
+                    edge_color="gray",
+                    edge_linewidth=0.7,
+                    edge_zorder=1,
+                    ladderize=True,
+                ),
+            )
+            sns.despine(ax=ax_tree, top=True, right=True, bottom=True)
+            ax_tree.set_ylim(ax_hw.get_ylim())
+            ax_tree.set_aspect("auto")
+            ax_tree.yaxis.set_major_locator(MaxNLocator(integer=True))
+            ax_tree.yaxis.set_major_formatter(
+                FuncFormatter(lambda x, _: f"{abs(int(round(x)))}"),
+            )
+
+    return (make_phylogeny_plot,)
+
+
+@app.cell
+def def_make_strain_graph_plot(ig, iplotx, np, pathlib, plt, sns, tp):
+    def make_strain_graph_plot(
+        N_SITES: int,
+        records_df,
+        max_n: int = 4,
+        palette: str = "rocket_r",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Plot final-step strains as undirected graphs at thresholds n=1..max_n.
+
+        Nodes are unique strains (sized by population copies, colored by
+        Hamming weight, 80% alpha). Edges connect strains within Hamming
+        distance ``n``. For ``n > 1`` only edges that are not implicitly
+        present via a 2-hop path through previously-added edges are drawn,
+        with line thickness encoding the threshold ``n`` at which the edge
+        was introduced.
+        """
+        extant = records_df[records_df["extant"]].copy()
+        if len(extant) == 0:
+            print("  (no extant records --- skipping strain graph plot)")
+            return
+
+        genomes = extant["genome"].astype("int64").to_numpy()
+        strains, counts = np.unique(genomes, return_counts=True)
+        n_strains = int(strains.size)
+        if n_strains < 2:
+            print(
+                f"  (only {n_strains} strain --- skipping strain graph plot)"
+            )
+            return
+
+        hamming_weights = np.array(
+            [bin(int(s)).count("1") for s in strains], dtype=int
+        )
+
+        xor = strains[:, None] ^ strains[None, :]
+        dists = np.zeros_like(xor, dtype=np.int32)
+        tmp = xor.copy()
+        while tmp.any():
+            dists += (tmp & 1).astype(np.int32)
+            tmp >>= 1
+
+        cumulative = {}  # (i, j) with i < j -> threshold n at which added
+        adjacency = [set() for _ in range(n_strains)]
+        snapshots = []
+        for n in range(1, max_n + 1):
+            iu, ju = np.where(np.triu(dists == n, k=1))
+            for i, j in zip(iu.tolist(), ju.tolist()):
+                if n > 1 and adjacency[i] & adjacency[j]:
+                    continue
+                cumulative[(i, j)] = n
+                adjacency[i].add(j)
+                adjacency[j].add(i)
+            snapshots.append((n, dict(cumulative)))
+
+        palette_colors = sns.color_palette(palette, N_SITES + 1)
+        node_facecolors = [
+            (*palette_colors[int(hw)], 0.8) for hw in hamming_weights
+        ]
+
+        max_count = int(counts.max())
+        sizes = 4.0 + 18.0 * np.sqrt(counts / max_count)
+
+        # Label only the dominant strains: those carrying more than 10% of
+        # the sampled population, annotated with their Hamming weight.
+        total = int(counts.sum())
+        vertex_labels = [
+            str(int(hamming_weights[i])) if counts[i] > 0.10 * total else ""
+            for i in range(n_strains)
+        ]
+
+        # Layout: kamada_kawai on the densest graph (max_n) so vertex
+        # positions are stable across subplots.
+        ref_graph = ig.Graph(n=n_strains)
+        ref_graph.add_edges(list(cumulative.keys()))
+        if ref_graph.ecount() > 0:
+            try:
+                layout = ref_graph.layout_kamada_kawai()
+            except Exception:
+                layout = ref_graph.layout_fruchterman_reingold()
+        else:
+            layout = ref_graph.layout_circle()
+        layout_coords = [tuple(c) for c in layout.coords]
+
+        with tp.teed(
+            plt.subplots,
+            nrows=1,
+            ncols=max_n,
+            figsize=(4.5 * max_n, 4.5),
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            if max_n == 1:
+                axes = [axes]
+
+            for ax, (n, edges_dict) in zip(axes, snapshots):
+                edges = list(edges_dict.keys())
+                # 1-hop edges thickest, with progressively thinner widths
+                # for higher-n edges; n>1 edges drawn dashed to distinguish
+                # them from direct mutational neighbors.
+                widths = [3.0 / edges_dict[e] for e in edges]
+                linestyles = [
+                    "-" if edges_dict[e] == 1 else "--" for e in edges
+                ]
+
+                g_plot = ig.Graph(n=n_strains)
+                if edges:
+                    g_plot.add_edges(edges)
+
+                iplotx.network(
+                    g_plot,
+                    layout=layout_coords,
+                    vertex_facecolor=node_facecolors,
+                    vertex_edgecolor="black",
+                    vertex_size=sizes.tolist(),
+                    vertex_labels=vertex_labels,
+                    vertex_label_color="black",
+                    vertex_label_size=8,
+                    edge_linewidth=widths if widths else 1.0,
+                    edge_linestyle=linestyles if linestyles else "-",
+                    edge_color="gray",
+                    ax=ax,
+                    show=False,
+                )
+                ax.set_title(f"n = {n}")
+                ax.set_aspect("equal")
+
+            # Match make_phylogeny_plot's legend: span the same HW limits
+            # (min/max of present Hamming weights), with up to 4
+            # evenly-spaced entries.
+            present_hw = sorted(int(w) for w in set(hamming_weights.tolist()))
+            if len(present_hw) > 4:
+                idx = np.unique(
+                    np.linspace(0, len(present_hw) - 1, 4).round().astype(int)
+                ).tolist()
+                legend_hw = [present_hw[i] for i in idx]
+            else:
+                legend_hw = present_hw
+
+            handles = [
+                plt.Line2D(
+                    [0],
+                    [0],
+                    marker="o",
+                    color="w",
+                    markerfacecolor=(*palette_colors[w], 0.8),
+                    markeredgecolor="black",
+                    markersize=10,
+                    label=f"HW {w}",
+                )
+                for w in legend_hw
+            ]
+            axes[-1].legend(
+                handles=handles,
+                title="Hamming weight",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+            )
+
+    return (make_strain_graph_plot,)
+
+
+@app.cell
+def def_make_strain_curves_plot(np, pathlib, plt, sns, strain_palette, tp):
+    def make_strain_curves_plot(
+        N_SITES: int,
+        traj_df,
+        strain_df,
+        palette: str = "husl",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Two-panel stacked figure: top = per-strain population-average
+        susceptibility (dashed), bottom = per-strain prevalence (solid).
+        Strains are color-coded by Hamming weight (hue) with lightness
+        disambiguating strains that share a Hamming weight.
+        """
+        n_strains = 1 << N_SITES
+        steps = traj_df["Step"].to_numpy()
+
+        susc_by_site_bit = np.empty((len(traj_df), N_SITES, 2), dtype=float)
+        for site in range(N_SITES):
+            for bit in range(2):
+                susc_by_site_bit[:, site, bit] = traj_df[
+                    f"Susc_S{site}_B{bit}"
+                ].to_numpy()
+
+        # Susceptibility to strain s = product over sites of Susc_S{site}_B{bit}
+        # where `bit` is the allele of strain s at that site.
+        susc_per_strain = np.ones((len(traj_df), n_strains), dtype=float)
+        for s in range(n_strains):
+            for site in range(N_SITES):
+                bit = (s >> site) & 1
+                susc_per_strain[:, s] *= susc_by_site_bit[:, site, bit]
+
+        palette_colors = strain_palette(N_SITES, base_palette=palette)
+
+        with tp.teed(
+            plt.subplots,
+            nrows=2,
+            ncols=1,
+            figsize=(8, 6),
+            sharex=True,
+            gridspec_kw={"hspace": 0.05},
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_susc, ax_prev = axes
+
+            for s in range(n_strains):
+                color = palette_colors[s]
+                label = f"{s:0{N_SITES}b}"
+                ax_susc.plot(
+                    steps,
+                    susc_per_strain[:, s],
+                    color=color,
+                    linestyle="--",
+                    linewidth=1.5,
+                    label=label,
+                )
+
+                strain_s = strain_df[strain_df["strain"] == s]
+                strain_s = strain_s.sort_values("Step")
+                ax_prev.plot(
+                    strain_s["Step"].to_numpy(),
+                    strain_s["count"].to_numpy(),
+                    color=color,
+                    linestyle="-",
+                    linewidth=1.5,
+                    label=label,
+                )
+
+            ax_susc.set_ylabel("Population Susceptibility")
+            ax_susc.set_ylim(0.0, 1.0)
+            ax_prev.set_ylabel("Case Burden")
+            ax_prev.set_xlabel("Time")
+            ax_prev.set_ylim(bottom=0.0)
+
+            ax_susc.legend(
+                title="strain",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1 if n_strains <= 8 else 2,
+                fontsize=8,
+            )
+            sns.despine(ax=ax_susc)
+            sns.despine(ax=ax_prev)
+
+    return (make_strain_curves_plot,)
+
+
+@app.cell
+def def_make_allele_curves_plot(allele_palette, np, pathlib, plt, sns, tp):
+    def make_allele_curves_plot(
+        N_SITES: int,
+        traj_df,
+        strain_df,
+        palette: str = "husl",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Two-panel stacked figure aggregated by individual allele:
+        top = per-(site, allele) population-average susceptibility
+        (dashed); bottom = per-(site, allele) prevalence (solid). Each
+        site gets its own ggplot-style HCL hue; the two alleles within
+        a site are split by lightness (allele 0 darker, allele 1 lighter).
+        """
+        n_strains = 1 << N_SITES
+        steps = traj_df["Step"].to_numpy()
+
+        # Per-(site, allele) susceptibility comes straight from the
+        # `Susc_S{site}_B{bit}` columns logged by simulate().
+        susc_per_allele = np.empty((len(traj_df), N_SITES, 2), dtype=float)
+        for site in range(N_SITES):
+            for bit in range(2):
+                susc_per_allele[:, site, bit] = traj_df[
+                    f"Susc_S{site}_B{bit}"
+                ].to_numpy()
+
+        # Per-(site, allele) prevalence is the sum of strain prevalences
+        # over strains carrying that allele at that site.
+        unique_steps = sorted(strain_df["Step"].unique())
+        step_to_idx = {t: i for i, t in enumerate(unique_steps)}
+        prev_per_allele = np.zeros(
+            (len(unique_steps), N_SITES, 2), dtype=float
+        )
+        for s in range(n_strains):
+            sub = strain_df[strain_df["strain"] == s]
+            for _, row in sub.iterrows():
+                idx = step_to_idx[row["Step"]]
+                count = float(row["count"])
+                for site in range(N_SITES):
+                    bit = (s >> site) & 1
+                    prev_per_allele[idx, site, bit] += count
+
+        site_allele_to_color = allele_palette(N_SITES, base_palette=palette)
+
+        with tp.teed(
+            plt.subplots,
+            nrows=2,
+            ncols=1,
+            figsize=(8, 6),
+            sharex=True,
+            gridspec_kw={"hspace": 0.05},
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_susc, ax_prev = axes
+
+            for site in range(N_SITES):
+                for allele in (0, 1):
+                    color = site_allele_to_color[(site, allele)]
+                    label = f"S{site}A{allele}"
+                    ax_susc.plot(
+                        steps,
+                        susc_per_allele[:, site, allele],
+                        color=color,
+                        linestyle="--",
+                        linewidth=1.5,
+                        label=label,
+                    )
+                    ax_prev.plot(
+                        unique_steps,
+                        prev_per_allele[:, site, allele],
+                        color=color,
+                        linestyle="-",
+                        linewidth=1.5,
+                        label=label,
+                    )
+
+            ax_susc.set_ylabel("Population Susceptibility")
+            ax_susc.set_ylim(0.0, 1.0)
+            ax_prev.set_ylabel("Case Burden")
+            ax_prev.set_xlabel("Time")
+            ax_prev.set_ylim(bottom=0.0)
+
+            ax_susc.legend(
+                title="site / allele",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1,
+                fontsize=8,
+            )
+            sns.despine(ax=ax_susc)
+            sns.despine(ax=ax_prev)
+
+    return (make_allele_curves_plot,)
+
+
+@app.cell
+def def_make_r_curves_plot(np, pathlib, plt, sns, strain_palette, tp):
+    def make_r_curves_plot(
+        N_SITES: int,
+        traj_df,
+        strain_df,
+        CONTACT_RATE: float,
+        RECOVERY_RATE: float,
+        POP_SIZE: int,
+        prev_floor: float = 1.0,
+        palette: str = "husl",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Two-panel stacked figure of per-strain reproduction number:
+        top = theoretical R(t, s) = (CONTACT_RATE/RECOVERY_RATE) * S_s(t)
+        (dashed; S_s(t) is approximated as the product of per-allele
+        population-average susceptibilities for the bits of strain s);
+        bottom = actual R(t, s) = 1 + (1/RECOVERY_RATE) * d ln I_s / dt
+        (solid; I_s(t) read from `strain_df['count']`, which carries the
+        per-strain population-fraction prevalence; the log-derivative is
+        computed via `np.gradient` and masked where `I_s * POP_SIZE` is
+        below `prev_floor` infected hosts to avoid amplifying
+        quantization noise from low-occupancy strains). Strains are
+        color-coded by Hamming weight (hue) with lightness disambiguating
+        strains that share a Hamming weight. R = 1 is drawn as a dotted
+        reference line on both panels.
+        """
+        n_strains = 1 << N_SITES
+        traj_df = traj_df.sort_values("Step")
+        steps = traj_df["Step"].to_numpy(dtype=float)
+
+        susc_by_site_bit = np.empty((len(traj_df), N_SITES, 2), dtype=float)
+        for site in range(N_SITES):
+            for bit in range(2):
+                susc_by_site_bit[:, site, bit] = traj_df[
+                    f"Susc_S{site}_B{bit}"
+                ].to_numpy()
+
+        susc_per_strain = np.ones((len(traj_df), n_strains), dtype=float)
+        for s in range(n_strains):
+            for site in range(N_SITES):
+                bit = (s >> site) & 1
+                susc_per_strain[:, s] *= susc_by_site_bit[:, site, bit]
+
+        R0 = CONTACT_RATE / RECOVERY_RATE
+        r_theo_per_strain = R0 * susc_per_strain
+
+        unique_steps = np.array(sorted(strain_df["Step"].unique()), dtype=float)
+        prev_per_strain = np.zeros(
+            (len(unique_steps), n_strains), dtype=float
+        )
+        step_to_idx = {t: i for i, t in enumerate(unique_steps.tolist())}
+        for s in range(n_strains):
+            sub = strain_df[strain_df["strain"] == s]
+            for _, row in sub.iterrows():
+                prev_per_strain[step_to_idx[row["Step"]], s] = float(
+                    row["count"]
+                )
+
+        r_actual_per_strain = np.full_like(prev_per_strain, np.nan)
+        for s in range(n_strains):
+            i_s = prev_per_strain[:, s]
+            valid = i_s * POP_SIZE > prev_floor
+            if valid.sum() < 3:
+                continue
+            log_i = np.full_like(i_s, np.nan)
+            log_i[valid] = np.log(i_s[valid])
+            dlog_dt = np.gradient(log_i, unique_steps)
+            r = 1.0 + dlog_dt / RECOVERY_RATE
+            r_actual_per_strain[valid, s] = r[valid]
+
+        palette_colors = strain_palette(N_SITES, base_palette=palette)
+
+        with tp.teed(
+            plt.subplots,
+            nrows=2,
+            ncols=1,
+            figsize=(8, 6),
+            sharex=True,
+            gridspec_kw={"hspace": 0.05},
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_theo, ax_actual = axes
+
+            for s in range(n_strains):
+                color = palette_colors[s]
+                label = f"{s:0{N_SITES}b}"
+                ax_theo.plot(
+                    steps,
+                    r_theo_per_strain[:, s],
+                    color=color,
+                    linestyle="--",
+                    linewidth=1.5,
+                    label=label,
+                )
+                ax_actual.plot(
+                    unique_steps,
+                    r_actual_per_strain[:, s],
+                    color=color,
+                    linestyle="-",
+                    linewidth=1.5,
+                    label=label,
+                )
+
+            for ax in (ax_theo, ax_actual):
+                ax.axhline(1.0, color="gray", linestyle=":", linewidth=1.0)
+
+            ax_theo.set_ylabel(r"theoretical $R(t)$")
+            ax_theo.set_ylim(bottom=0.0)
+            ax_actual.set_ylabel(r"actual $R(t)$")
+            ax_actual.set_xlabel("Time")
+
+            ax_theo.legend(
+                title="strain",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1 if n_strains <= 8 else 2,
+                fontsize=8,
+            )
+            sns.despine(ax=ax_theo)
+            sns.despine(ax=ax_actual)
+
+    return (make_r_curves_plot,)
+
+
+@app.cell
+def run_phylogeny_sweep(
+    ENGINE,
+    N_REPLICATES,
+    N_STEPS,
+    POP_SIZE,
+    POW,
+    SKIP_PLOTTING,
+    gc,
+    make_allele_curves_plot,
+    make_phylogeny_plot,
+    make_r_curves_plot,
+    make_strain_curves_plot,
+    make_strain_graph_plot,
+    pathlib,
+    pd,
+    reconstruct_phylogeny,
+    simulate,
+    uuid,
+):
+    PHYLO_MUTATION_RATE = 1e-5
+    POW_ = POW
+
+    nbname = pathlib.Path(__file__).stem
+    out_dir = pathlib.Path("outdata") / nbname
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    def _save_replicate(kind: str, uid: str, df) -> None:
+        rep_dir = out_dir / kind / uid
+        rep_dir.mkdir(parents=True, exist_ok=True)
+        rep_path = rep_dir / f"a={kind}+what={nbname}+ext=.pqt"
+        df.to_parquet(rep_path, index=False)
+        print(f"  wrote {kind} parquet ({len(df)} rows): {rep_path}")
+
+    traj_chunks = []
+    hw_chunks = []
+    strain_chunks = []
+    records_chunks = []
+    phylo_chunks = []
+
+    for _seed in range(1, N_REPLICATES + 1):
+        for PHYLO_N_SITES in (2, 3, 4):
+            replicate_uid = uuid.uuid4().hex
+            print(
+                f"=== seed={_seed} N_SITES={PHYLO_N_SITES} "
+                f"uid={replicate_uid} ===",
+            )
+            CONTACT_RATE_ = 0.35
+            RECOVERY_RATE_ = 0.1
+            _phylo_df, _hw_df, _strain_df, _records_df = simulate(
+                MUTATION_RATE=PHYLO_MUTATION_RATE,
+                N_SITES=PHYLO_N_SITES,
+                N_STEPS=N_STEPS,
+                POP_SIZE=POP_SIZE,
+                CONTACT_RATE=CONTACT_RATE_,
+                RECOVERY_RATE=RECOVERY_RATE_,
+                WANING_RATE=0.01,
+                IMMUNE_STRENGTH=0.7,
+                SEED_COUNT=2,
+                IMMUNITY_FLOOR=0.05,
+                IMMUNITY_CEILING=1.0,
+                seed=_seed,
+                track_phylogeny=True,
+                N_SAMPLE=200,
+                pow=POW_,
+            )
+            print(f"  snapshot rows: {len(_records_df)}")
+
+            _params = {
+                "replicate_uid": replicate_uid,
+                "seed": _seed,
+                "n_sites": PHYLO_N_SITES,
+                "pop_size": POP_SIZE,
+                "n_steps": N_STEPS,
+                "engine": ENGINE,
+                "pow": POW_,
+            }
+            _traj_stamped = _phylo_df.assign(**_params)
+            _hw_stamped = _hw_df.assign(**_params)
+            _strain_stamped = _strain_df.assign(**_params)
+            traj_chunks.append(_traj_stamped)
+            hw_chunks.append(_hw_stamped)
+            strain_chunks.append(_strain_stamped)
+            _save_replicate("traj", replicate_uid, _traj_stamped)
+            _save_replicate("hw", replicate_uid, _hw_stamped)
+            _save_replicate("strain", replicate_uid, _strain_stamped)
+
+            _records_stamped = _records_df.assign(**_params)
+            records_chunks.append(_records_stamped)
+            _save_replicate("records", replicate_uid, _records_stamped)
+
+            if SKIP_PLOTTING:
+                print("  (SKIP_PLOTTING=True — skipping strain curves)")
+            else:
+                for palette in "husl", "hls", "Set2":
+                    make_strain_curves_plot(
+                        PHYLO_N_SITES,
+                        _phylo_df,
+                        _strain_df,
+                        palette=palette,
+                        teeplot_outattrs={
+                            "a": "strain-curves",
+                            "n_sites": PHYLO_N_SITES,
+                            "n_steps": int(_phylo_df["Step"].max()) + 1,
+                            "replicate": _seed,
+                            "palette": palette,
+                            "pow": POW_,
+                        },
+                    )
+                    make_allele_curves_plot(
+                        PHYLO_N_SITES,
+                        _phylo_df,
+                        _strain_df,
+                        palette=palette,
+                        teeplot_outattrs={
+                            "a": "allele-curves",
+                            "n_sites": PHYLO_N_SITES,
+                            "n_steps": int(_phylo_df["Step"].max()) + 1,
+                            "replicate": _seed,
+                            "palette": palette,
+                            "pow": POW_,
+                        },
+                    )
+                    make_r_curves_plot(
+                        PHYLO_N_SITES,
+                        _phylo_df,
+                        _strain_df,
+                        CONTACT_RATE=CONTACT_RATE_,
+                        RECOVERY_RATE=RECOVERY_RATE_,
+                        POP_SIZE=POP_SIZE,
+                        palette=palette,
+                        teeplot_outattrs={
+                            "a": "r-curves",
+                            "n_sites": PHYLO_N_SITES,
+                            "n_steps": int(_phylo_df["Step"].max()) + 1,
+                            "replicate": _seed,
+                            "palette": palette,
+                            "pow": POW_,
+                        },
+                    )
+
+            if len(_records_df) == 0:
+                print("  (no infected hosts --- skipping plot)")
+                del _phylo_df, _hw_df, _strain_df, _records_df
+                gc.collect()
+                continue
+
+            print(f"  extant rows: {int(_records_df['extant'].sum())}")
+            for palette in "rocket_r", "tab20", "tab10":
+                if SKIP_PLOTTING:
+                    print("  (SKIP_PLOTTING=True — skipping strain graph)")
+                else:
+                    make_strain_graph_plot(
+                        PHYLO_N_SITES,
+                        _records_df,
+                        max_n=4,
+                        palette=palette,
+                        teeplot_outattrs={
+                            "a": "strain-graph",
+                            "n_sites": PHYLO_N_SITES,
+                            "n_steps": int(_phylo_df["Step"].max()) + 1,
+                            "replicate": _seed,
+                            "palette": palette,
+                            "pow": POW_,
+                        },
+                    )
+            _phylogeny_df = reconstruct_phylogeny(_records_df)
+            del _records_df
+            gc.collect()
+            print(f"  reconstructed: {len(_phylogeny_df)} nodes")
+            print(f"  extant tips: {int(_phylogeny_df['extant'].sum())}")
+
+            _phylo_stamped = _phylogeny_df.assign(**_params)
+            phylo_chunks.append(_phylo_stamped)
+            _save_replicate("phylo", replicate_uid, _phylo_stamped)
+
+            for palette in "rocket_r", "tab20", "tab10":
+                if SKIP_PLOTTING:
+                    print("  (SKIP_PLOTTING=True — skipping plot)")
+                else:
+                    make_phylogeny_plot(
+                        PHYLO_N_SITES,
+                        _phylo_df,
+                        _hw_df,
+                        _phylogeny_df,
+                        seed=_seed,
+                        palette=palette,
+                        teeplot_outattrs={
+                            "n_sites": PHYLO_N_SITES,
+                            "n_steps": int(_phylo_df["Step"].max()) + 1,
+                            "replicate": _seed,
+                            "palette": palette,
+                            "method": "hstrat-surface",
+                            "pow": POW_,
+                        },
+                    )
+            del _phylo_df, _hw_df, _strain_df, _phylogeny_df
+            gc.collect()
+
+    traj_df_all = (
+        pd.concat(traj_chunks, ignore_index=True)
+        if traj_chunks
+        else pd.DataFrame()
+    )
+    hw_df_all = (
+        pd.concat(hw_chunks, ignore_index=True)
+        if hw_chunks
+        else pd.DataFrame()
+    )
+    strain_df_all = (
+        pd.concat(strain_chunks, ignore_index=True)
+        if strain_chunks
+        else pd.DataFrame()
+    )
+    records_df_all = (
+        pd.concat(records_chunks, ignore_index=True)
+        if records_chunks
+        else pd.DataFrame()
+    )
+    phylo_df_all = (
+        pd.concat(phylo_chunks, ignore_index=True)
+        if phylo_chunks
+        else pd.DataFrame()
+    )
+
+    traj_path = out_dir / f"a=traj+what={nbname}+ext=.pqt"
+    hw_path = out_dir / f"a=hw+what={nbname}+ext=.pqt"
+    strain_path = out_dir / f"a=strain+what={nbname}+ext=.pqt"
+    records_path = out_dir / f"a=records+what={nbname}+ext=.pqt"
+    phylo_path = out_dir / f"a=phylo+what={nbname}+ext=.pqt"
+    traj_df_all.to_parquet(traj_path, index=False)
+    hw_df_all.to_parquet(hw_path, index=False)
+    strain_df_all.to_parquet(strain_path, index=False)
+    records_df_all.to_parquet(records_path, index=False)
+    phylo_df_all.to_parquet(phylo_path, index=False)
+    print(f"wrote trajectory parquet ({len(traj_df_all)} rows): {traj_path}")
+    print(f"wrote hw parquet ({len(hw_df_all)} rows): {hw_path}")
+    print(f"wrote strain parquet ({len(strain_df_all)} rows): {strain_path}")
+    print(
+        f"wrote records parquet ({len(records_df_all)} rows): {records_path}"
+    )
+    print(f"wrote phylogeny parquet ({len(phylo_df_all)} rows): {phylo_path}")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -142,7 +142,7 @@ def delimit_simulation(mo):
     inherited from the 32-site notebook, this notebook renders an
     "r-curves" figure: a multi-row stack with the *expected* per-
     strain reproduction number on the very top row by itself, and
-    the *empirical* per-strain reproduction number on subsequent
+    the *actual* per-strain reproduction number on subsequent
     rows at increasing rolling-mean windows (unsmoothed first). Both
     per-step rates are scaled by the discrete-time R0 multiplier
     `(1 - RECOVERY_RATE) / RECOVERY_RATE` so the plotted values are
@@ -157,7 +157,7 @@ def delimit_simulation(mo):
     steps is `sum_{k=1}^inf (1 - p)^k = (1 - p) / p` (off-by-one if
     you forget the within-step recovery).
 
-    * `R_empirical(t, s) = new_infections(s, t) /
+    * `R_actual(t, s) = new_infections(s, t) /
       n_with_strain(s, t) * (1 - RECOVERY_RATE) / RECOVERY_RATE` --
       new strain-`s` infections caused per current strain-`s`
       infected per step, multiplied by the R0 multiplier, computed
@@ -1367,7 +1367,7 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
     ) -> None:
         """Multi-row figure of per-strain reproduction number. The
         first row plots the *expected* R per strain on its own; each
-        subsequent row plots the *empirical* R per strain at a
+        subsequent row plots the *actual* R per strain at a
         different rolling-mean window (unsmoothed first). Both per-
         step rates are scaled by the discrete-time R0 multiplier
         `(1 - RECOVERY_RATE) / RECOVERY_RATE` so the plotted values
@@ -1379,7 +1379,7 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
         primary faces an immediate recovery check before it can
         transmit at the next step.
 
-        * empirical R(t, s) = (new_infections(s, t) /
+        * actual R(t, s) = (new_infections(s, t) /
           n_with_strain(s, t)) * (1 - RECOVERY_RATE) / RECOVERY_RATE.
           Rolling-mean smoothed with the row's window.
         * expected R(t, s) = expected_R_per_step(s, t) *
@@ -1427,12 +1427,12 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
         expected_R_per_strain = expected_R_per_strain * r0_multiplier
 
         with np.errstate(divide="ignore", invalid="ignore"):
-            r_empirical_per_strain = np.where(
+            r_actual_per_strain = np.where(
                 prev_per_strain > 0,
                 new_inf_per_strain / prev_per_strain,
                 np.nan,
             )
-        r_empirical_per_strain = r_empirical_per_strain * r0_multiplier
+        r_actual_per_strain = r_actual_per_strain * r0_multiplier
 
         palette_colors = strain_palette(N_SITES, base_palette=palette)
 
@@ -1454,7 +1454,7 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
             teeplot_subdir=pathlib.Path(__file__).stem,
         ) as (fig, axes):
             ax_expected = axes[0]
-            empirical_axes = axes[1:]
+            actual_axes = axes[1:]
 
             for s in range(n_strains):
                 color = palette_colors[s]
@@ -1484,28 +1484,28 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
                 fontsize=8,
             )
 
-            for ax, w in zip(empirical_axes, windows):
+            for ax, w in zip(actual_axes, windows):
                 for s in range(n_strains):
                     color = palette_colors[s]
-                    empirical = pd.Series(r_empirical_per_strain[:, s])
+                    actual = pd.Series(r_actual_per_strain[:, s])
                     if w > 1:
-                        empirical = empirical.rolling(
+                        actual = actual.rolling(
                             window=w,
                             min_periods=max(1, w // 4),
                             center=True,
                         ).mean()
                     ax.plot(
                         unique_steps,
-                        empirical.to_numpy(),
+                        actual.to_numpy(),
                         color=color,
                         linestyle="-",
                         linewidth=1.2,
                     )
                 ax.axhline(1.0, color="gray", linestyle=":", linewidth=0.8)
-                ax.set_ylabel(f"empirical R\nrolling window = {w}")
+                ax.set_ylabel(f"actual R\nrolling window = {w}")
                 sns.despine(ax=ax)
 
-            empirical_axes[-1].set_xlabel("Time")
+            actual_axes[-1].set_xlabel("Time")
 
     return (make_r_curves_plot,)
 

--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -1315,10 +1315,10 @@ def def_make_r_curves_plot(np, pathlib, plt, sns, strain_palette, tp):
         R0 = CONTACT_RATE / RECOVERY_RATE
         r_theo_per_strain = R0 * susc_per_strain
 
-        unique_steps = np.array(sorted(strain_df["Step"].unique()), dtype=float)
-        prev_per_strain = np.zeros(
-            (len(unique_steps), n_strains), dtype=float
+        unique_steps = np.array(
+            sorted(strain_df["Step"].unique()), dtype=float
         )
+        prev_per_strain = np.zeros((len(unique_steps), n_strains), dtype=float)
         step_to_idx = {t: i for i, t in enumerate(unique_steps.tolist())}
         for s in range(n_strains):
             sub = strain_df[strain_df["strain"] == s]

--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -144,35 +144,40 @@ def delimit_simulation(mo):
     strain reproduction number on the very top row by itself, and
     the *empirical* per-strain reproduction number on subsequent
     rows at increasing rolling-mean windows (unsmoothed first). Both
-    are scaled by the expected infectious period `1 / RECOVERY_RATE`
-    so the plotted values are total expected new infections per
-    infected over an infection (i.e. an `R0`-like quantity) rather
-    than the per-step rate, and `R = 1` is drawn as the
-    epidemic-threshold reference line.
+    per-step rates are scaled by the discrete-time R0 multiplier
+    `(1 - RECOVERY_RATE) / RECOVERY_RATE` so the plotted values are
+    the expected total infections caused by a single primary (an
+    `R0`-like quantity) rather than the per-step rate, and `R = 1`
+    is drawn as the epidemic-threshold reference line. The factor
+    is `(1 - p) / p` rather than `1 / p` because
+    `update_recoveries` runs after `transmit_infection` within the
+    same step, so a primary newly infected in step `t` faces an
+    immediate recovery check before participating as a source at
+    step `t+1`; the expected number of future transmit-as-source
+    steps is `sum_{k=1}^inf (1 - p)^k = (1 - p) / p` (off-by-one if
+    you forget the within-step recovery).
 
     * `R_empirical(t, s) = new_infections(s, t) /
-      n_with_strain(s, t) / RECOVERY_RATE` -- the number of new
-      strain-`s` infections caused per current strain-`s` infected
-      per step, multiplied by the expected infectious period,
-      computed from instrumentation logged inside `simulate()`.
+      n_with_strain(s, t) * (1 - RECOVERY_RATE) / RECOVERY_RATE` --
+      new strain-`s` infections caused per current strain-`s`
+      infected per step, multiplied by the R0 multiplier, computed
+      from instrumentation logged inside `simulate()`.
       `new_infections` is captured pre-mutation in
       `update_simulation()` so the strain label reflects the strain
       that actually transmitted, not its post-mutation descendant.
 
-    * `R_expected(t, s) = R_expected_per_step(s, t) / RECOVERY_RATE`,
-      where `R_expected_per_step(s, t)` is the average over the
-      population of the probability that strain `s` infects a
-      randomly-sampled individual on a single contact in one step.
-      Currently-infected hosts contribute zero since they cannot be
-      re-infected --- the `(host_statuses == 0)` mask zeros out
-      their per-host susceptibilities before averaging over the full
-      `POP_SIZE`, so the mean already accounts for the susceptible-
-      only fraction. The per-step quantity is logged as
-      `strain_df["expected_R"]` alongside `count` and
-      `new_infections`; multiplying by the expected infectious
-      period gives the analog of `R0` (so `R_expected(s, t) *
-      n_with_strain(s, t) * RECOVERY_RATE` is the expected number of
-      new strain-`s` infections per step).
+    * `R_expected(t, s) = R_expected_per_step(s, t) *
+      (1 - RECOVERY_RATE) / RECOVERY_RATE`, where
+      `R_expected_per_step(s, t)` is the average over the population
+      of the probability that strain `s` infects a randomly-sampled
+      individual on a single contact in one step. Currently-infected
+      hosts contribute zero since they cannot be re-infected --- the
+      `(host_statuses == 0)` mask zeros out their per-host
+      susceptibilities before averaging over the full `POP_SIZE`, so
+      the mean already accounts for the susceptible-only fraction.
+      The per-step quantity is logged as `strain_df["expected_R"]`
+      alongside `count` and `new_infections`; multiplying by the
+      R0 multiplier gives the analog of `R0`.
 
     Phylogeny estimation still uses *hereditary stratigraphic surface*
     annotations (see https://hstrat.rtfd.io). Each infected host carries
@@ -1363,25 +1368,28 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
         """Multi-row figure of per-strain reproduction number. The
         first row plots the *expected* R per strain on its own; each
         subsequent row plots the *empirical* R per strain at a
-        different rolling-mean window (unsmoothed first). Both are
-        scaled by the expected infectious period `1 / RECOVERY_RATE`
-        so the plotted values are total expected new infections per
-        infected over an infection (an `R0`-like quantity), not the
-        per-step rate.
+        different rolling-mean window (unsmoothed first). Both per-
+        step rates are scaled by the discrete-time R0 multiplier
+        `(1 - RECOVERY_RATE) / RECOVERY_RATE` so the plotted values
+        are the expected number of total transmissions caused by a
+        single primary infection (an `R0`-like quantity) rather than
+        the per-step rate. The factor is `(1 - p) / p` rather than
+        `1 / p` because `update_recoveries` runs after
+        `transmit_infection` within the same step, so a just-infected
+        primary faces an immediate recovery check before it can
+        transmit at the next step.
 
         * empirical R(t, s) = (new_infections(s, t) /
-          n_with_strain(s, t)) * (1 / RECOVERY_RATE) -- new strain-s
-          infections per current strain-s infected per step,
-          multiplied by the expected infectious period in steps.
+          n_with_strain(s, t)) * (1 - RECOVERY_RATE) / RECOVERY_RATE.
           Rolling-mean smoothed with the row's window.
         * expected R(t, s) = expected_R_per_step(s, t) *
-          (1 / RECOVERY_RATE), where the per-step quantity is the
-          population-average probability that strain s infects a
-          randomly-sampled individual on a single contact in one step
-          (logged per step as `strain_df["expected_R"]`, with
-          currently-infected hosts contributing 0 since they cannot
-          be re-infected). Plotted unsmoothed since it is already a
-          smooth function of population state.
+          (1 - RECOVERY_RATE) / RECOVERY_RATE, where the per-step
+          quantity is the population-average probability that strain
+          s infects a randomly-sampled individual on a single contact
+          in one step (logged per step as `strain_df["expected_R"]`,
+          with currently-infected hosts contributing 0 since they
+          cannot be re-infected). Plotted unsmoothed since it is
+          already a smooth function of population state.
 
         Strains are color-coded by Hamming weight (hue) with
         lightness disambiguating strains of the same weight. The
@@ -1406,9 +1414,17 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
             new_inf_per_strain[i, s] = float(row.get("new_infections", 0.0))
             expected_R_per_strain[i, s] = float(row.get("expected_R", 0.0))
 
-        # Convert per-step rates to per-infectious-period totals.
-        infectious_period = 1.0 / RECOVERY_RATE
-        expected_R_per_strain = expected_R_per_strain * infectious_period
+        # Convert per-step rates to per-primary R0-like totals. A
+        # primary newly infected in step t's transmit_infection faces
+        # update_recoveries in the same step, so it participates as a
+        # source in step t+1 only with prob (1 - p), in step t+2 with
+        # prob (1 - p)^2, etc. The expected number of future
+        # transmit_infection participations is therefore
+        # sum_{k=1}^inf (1-p)^k = (1 - p) / p, NOT 1 / p (off-by-one
+        # if you forget that update_recoveries runs after
+        # transmit_infection within the same step).
+        r0_multiplier = (1.0 - RECOVERY_RATE) / RECOVERY_RATE
+        expected_R_per_strain = expected_R_per_strain * r0_multiplier
 
         with np.errstate(divide="ignore", invalid="ignore"):
             r_empirical_per_strain = np.where(
@@ -1416,7 +1432,7 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
                 new_inf_per_strain / prev_per_strain,
                 np.nan,
             )
-        r_empirical_per_strain = r_empirical_per_strain * infectious_period
+        r_empirical_per_strain = r_empirical_per_strain * r0_multiplier
 
         palette_colors = strain_palette(N_SITES, base_palette=palette)
 


### PR DESCRIPTION
## Summary
This PR adds a new marimo notebook (`2026-05-06-allele-abm-r-per-strain.py`) that extends the allele-based agent-based model (ABM) to track per-strain reproduction numbers alongside phylogenetic reconstruction. The notebook is designed as an R-per-strain companion to the existing strain-curves notebook, with a focus on smaller site counts (N_SITES = 2-4) to enable detailed per-strain analysis.

## Key Changes

- **New ABM simulation notebook** with support for:
  - Vectorized pathogen genome and host immunity tracking using numpy/cupy backends
  - Hereditary stratigraphic surface annotations (dstream) for phylogeny estimation
  - Per-step logging of Hamming-weight and per-strain prevalence trajectories
  - Optional phylogenetic tree reconstruction via hstrat surface unpacking

- **Per-strain reproduction number analysis**:
  - Theoretical R(t,s) = (CONTACT_RATE/RECOVERY_RATE) × S_s(t) using product of per-allele susceptibilities
  - Actual R(t,s) derived from prevalence trajectories via log-derivative with finite differences
  - Visualization with R=1 epidemic threshold reference line

- **Visualization functions**:
  - `make_phylogeny_plot()`: Phylogeny tree with Hamming-weight stackplots
  - `make_strain_graph_plot()`: Strain networks at multiple Hamming-distance thresholds
  - `make_strain_curves_plot()`: Per-strain susceptibility and prevalence curves
  - `make_allele_curves_plot()`: Per-allele aggregated curves
  - `make_r_curves_plot()`: Theoretical vs. actual per-strain reproduction numbers

- **Configurable parameters** via CLI args:
  - Population size, simulation steps, replicates, compute engine (numpy/cupy)
  - Mutation rates, recovery/contact rates, immunity dynamics
  - Phylogeny tracking with dstream algorithm selection

## Implementation Details

- Uses uint16/uint32/uint64 genome encoding based on N_SITES to avoid truncation
- Implements within-host mutation probability calculation with immunity-dependent bias
- Supports both uniform and per-site mutation rates
- Includes GPU acceleration via cupy with automatic fallback to numpy
- Phylogenetic reconstruction uses AssignOriginTimeNodeRankTriePostprocessor for step-aligned origin times
- Strain graph layout uses Kamada-Kawai algorithm with fallback to Fruchterman-Reingold

https://claude.ai/code/session_011H5HPBvbRtwituXJCadTrt