### PR TITLE
Add density heatmap binned by Hamming distance to end-state strain

### DIFF
--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -1658,7 +1658,7 @@ def run_phylogeny_sweep(
         (3, POW),
         (4, POW),
         (8, 0.5),
-        (16, 0.25),
+        # (16, 0.25),
     )
 
     nbname = pathlib.Path(__file__).stem

--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -619,9 +619,7 @@ def def_simulate(
             # would exceed the cap (e.g. N_SITES >= 16 sweeps); the
             # r-curves plot is also skipped for those conditions, so
             # the all-zero column is never consumed downstream.
-            _expected_R_tensor_bytes = (
-                POP_SIZE * n_strains * N_SITES * 4
-            )
+            _expected_R_tensor_bytes = POP_SIZE * n_strains * N_SITES * 4
             if _expected_R_tensor_bytes <= 2 * 1024**3:
                 host_susc_2d = (
                     1.0 - (IMMUNE_STRENGTH * host_immunities)

--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -1511,6 +1511,82 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
 
 
 @app.cell
+def def_make_density_heatmap_plot(np, pathlib, plt, sns, tp):
+    def make_density_heatmap_plot(
+        N_SITES: int,
+        strain_df,
+        cmap: str = "rocket_r",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Heatmap of population density binned by Hamming distance to
+        the end-state most populous strain. y-axis is the number of bits
+        in common with that reference strain (top = identical with the
+        end-state strain, bottom = its complement); x-axis is time. Each
+        cell aggregates the population fraction of strains that share
+        the given number of bits with the reference at the given step.
+        """
+        n_strains = 1 << N_SITES
+        unique_steps = np.array(
+            sorted(strain_df["Step"].unique()), dtype=int
+        )
+        T = len(unique_steps)
+        step_to_idx = {t: i for i, t in enumerate(unique_steps.tolist())}
+
+        final_step = int(unique_steps.max())
+        final = strain_df[strain_df["Step"] == final_step]
+        end_strain = int(final.loc[final["count"].idxmax(), "strain"])
+
+        bits_in_common = np.array(
+            [
+                N_SITES - bin(int(s) ^ end_strain).count("1")
+                for s in range(n_strains)
+            ],
+            dtype=int,
+        )
+
+        density = np.zeros((N_SITES + 1, T), dtype=float)
+        for _, row in strain_df.iterrows():
+            i = step_to_idx[int(row["Step"])]
+            s = int(row["strain"])
+            density[bits_in_common[s], i] += float(row["count"])
+
+        with tp.teed(
+            plt.subplots,
+            figsize=(8, 1.5 + 0.4 * (N_SITES + 1)),
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, ax):
+            # origin="lower" places density[0, :] (bits_in_common = 0,
+            # i.e. complement of end-state strain) at the bottom and
+            # density[N_SITES, :] (identical with end-state) at the top.
+            im = ax.imshow(
+                density,
+                origin="lower",
+                aspect="auto",
+                cmap=cmap,
+                extent=[
+                    float(unique_steps.min()) - 0.5,
+                    float(unique_steps.max()) + 0.5,
+                    -0.5,
+                    N_SITES + 0.5,
+                ],
+                interpolation="nearest",
+            )
+            ax.set_yticks(np.arange(N_SITES + 1))
+            ax.set_xlabel("Time")
+            ax.set_ylabel(
+                "bits in common with\nend-state strain "
+                f"{end_strain:0{N_SITES}b}"
+            )
+            cbar = fig.colorbar(im, ax=ax, pad=0.02)
+            cbar.set_label("Population fraction")
+            sns.despine(ax=ax)
+
+    return (make_density_heatmap_plot,)
+
+
+@app.cell
 def run_phylogeny_sweep(
     ENGINE,
     N_REPLICATES,
@@ -1520,6 +1596,7 @@ def run_phylogeny_sweep(
     SKIP_PLOTTING,
     gc,
     make_allele_curves_plot,
+    make_density_heatmap_plot,
     make_phylogeny_plot,
     make_r_curves_plot,
     make_strain_curves_plot,
@@ -1644,6 +1721,20 @@ def run_phylogeny_sweep(
                             "n_steps": int(_phylo_df["Step"].max()) + 1,
                             "replicate": _seed,
                             "palette": palette,
+                            "pow": POW_,
+                        },
+                    )
+                for cmap in "rocket_r", "viridis", "magma_r":
+                    make_density_heatmap_plot(
+                        PHYLO_N_SITES,
+                        _strain_df,
+                        cmap=cmap,
+                        teeplot_outattrs={
+                            "a": "density-heatmap",
+                            "n_sites": PHYLO_N_SITES,
+                            "n_steps": int(_phylo_df["Step"].max()) + 1,
+                            "replicate": _seed,
+                            "cmap": cmap,
                             "pow": POW_,
                         },
                     )

--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -1783,7 +1783,7 @@ def run_phylogeny_sweep(
                                 "pow": POW_,
                             },
                         )
-                for cmap in "rocket_r", "viridis", "magma_r":
+                for cmap in "rocket", "viridis", "magma":
                     make_density_heatmap_plot(
                         PHYLO_N_SITES,
                         _strain_df,

--- a/bindle/2026-05-06-allele-abm-r-per-strain.py
+++ b/bindle/2026-05-06-allele-abm-r-per-strain.py
@@ -134,11 +134,20 @@ def delimit_simulation(mo):
     ## Simulation Implementation
 
     This notebook is an R-per-strain companion to
-    `2026-05-03-allele-abm-strain-curves.py`: the sweep is restricted
-    to `N_SITES = 2, 3, 4` so that per-strain prevalence and
-    per-strain population-average susceptibility can be tracked by
-    individual strain (the strain count is `2**N_SITES`, capped here
-    at 16). In addition to the phylogeny-and-strain-network plots
+    `2026-05-03-allele-abm-strain-curves.py`: the low-`N_SITES` rows
+    of the sweep (`2, 3, 4`) keep the strain count
+    `2**N_SITES <= 16` so that per-strain prevalence and per-strain
+    population-average susceptibility can be tracked by individual
+    strain. The sweep is extended with two high-`N_SITES` rows
+    (`(N_SITES, pow) = (8, 0.5), (16, 0.25)`) for which the
+    per-strain stack-plot, R-curves, and strain-graph panels are
+    skipped (one line/node per strain is unreadable, and the dense
+    `(POP_SIZE, n_strains, N_SITES)` susceptibility tensor used for
+    expected-R is gated off above a memory cap). The Hamming-distance
+    density heatmap aggregates only `N_SITES + 1` bins, so it
+    continues to render at 8 and 16 sites.
+
+    In addition to the phylogeny-and-strain-network plots
     inherited from the 32-site notebook, this notebook renders an
     "r-curves" figure: a multi-row stack with the *expected* per-
     strain reproduction number on the very top row by itself, and
@@ -605,21 +614,33 @@ def def_simulate(
             # entries before averaging over the full POP_SIZE, so the
             # mean already accounts for the susceptible-only fraction.
             # Multiplying by n(s, t) gives the expected number of new
-            # strain-s infections per step.
-            host_susc_2d = (1.0 - (IMMUNE_STRENGTH * host_immunities)).reshape(
-                POP_SIZE, 2 * N_SITES
+            # strain-s infections per step. The dense
+            # (POP_SIZE, n_strains, N_SITES) tensor is skipped when it
+            # would exceed the cap (e.g. N_SITES >= 16 sweeps); the
+            # r-curves plot is also skipped for those conditions, so
+            # the all-zero column is never consumed downstream.
+            _expected_R_tensor_bytes = (
+                POP_SIZE * n_strains * N_SITES * 4
             )
-            strain_susc_per_host = host_susc_2d[:, _strain_cols].prod(axis=2)
-            strain_susc_per_host = xp.power(strain_susc_per_host, pow)
-            strain_susc_per_host = (
-                strain_susc_per_host * (host_statuses == 0)[:, None]
-            )
-            expected_R_per_strain = (
-                strain_susc_per_host.mean(axis=0) * CONTACT_RATE
-            )
-            expected_R_list = [
-                float(x) for x in expected_R_per_strain.tolist()
-            ]
+            if _expected_R_tensor_bytes <= 2 * 1024**3:
+                host_susc_2d = (
+                    1.0 - (IMMUNE_STRENGTH * host_immunities)
+                ).reshape(POP_SIZE, 2 * N_SITES)
+                strain_susc_per_host = host_susc_2d[:, _strain_cols].prod(
+                    axis=2,
+                )
+                strain_susc_per_host = xp.power(strain_susc_per_host, pow)
+                strain_susc_per_host = (
+                    strain_susc_per_host * (host_statuses == 0)[:, None]
+                )
+                expected_R_per_strain = (
+                    strain_susc_per_host.mean(axis=0) * CONTACT_RATE
+                )
+                expected_R_list = [
+                    float(x) for x in expected_R_per_strain.tolist()
+                ]
+            else:
+                expected_R_list = [0.0] * n_strains
 
             for w, count in enumerate(hw_prevalences):
                 hw_log.append(
@@ -1512,6 +1533,8 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
 
 @app.cell
 def def_make_density_heatmap_plot(np, pathlib, plt, sns, tp):
+    import matplotlib.colors as mcolors
+
     def make_density_heatmap_plot(
         N_SITES: int,
         strain_df,
@@ -1519,36 +1542,55 @@ def def_make_density_heatmap_plot(np, pathlib, plt, sns, tp):
         teeplot_outattrs: dict = {},
     ) -> None:
         """Heatmap of population density binned by Hamming distance to
-        the end-state most populous strain. y-axis is the number of bits
-        in common with that reference strain (top = identical with the
-        end-state strain, bottom = its complement); x-axis is time. Each
-        cell aggregates the population fraction of strains that share
-        the given number of bits with the reference at the given step.
+        the end-state most populous strain. y-axis is the number of
+        bits in common with that reference strain (top = identical
+        with the end-state strain, bottom = its complement); x-axis is
+        time. Each column is normalized to sum to 1, so cells encode
+        the proportion of *circulating* strains (not the host
+        population fraction) sharing the given number of bits with the
+        reference at the given step. The colormap is truncated and
+        true-zero cells are masked white so that barely-positive bins
+        are clearly distinguishable from empty bins.
         """
         n_strains = 1 << N_SITES
+
         unique_steps = np.array(
-            sorted(strain_df["Step"].unique()), dtype=int
+            sorted(strain_df["Step"].unique()), dtype=np.int64
         )
         T = len(unique_steps)
-        step_to_idx = {t: i for i, t in enumerate(unique_steps.tolist())}
-
         final_step = int(unique_steps.max())
+
         final = strain_df[strain_df["Step"] == final_step]
         end_strain = int(final.loc[final["count"].idxmax(), "strain"])
 
-        bits_in_common = np.array(
-            [
-                N_SITES - bin(int(s) ^ end_strain).count("1")
-                for s in range(n_strains)
-            ],
-            dtype=int,
+        bits_in_common = N_SITES - np.array(
+            [bin(int(s) ^ end_strain).count("1") for s in range(n_strains)],
+            dtype=np.int64,
         )
 
+        strains_arr = strain_df["strain"].to_numpy().astype(np.int64)
+        steps_arr = strain_df["Step"].to_numpy().astype(np.int64)
+        counts_arr = strain_df["count"].to_numpy(dtype=float)
+        bic_arr = bits_in_common[strains_arr]
+        step_idx_arr = np.searchsorted(unique_steps, steps_arr)
+
         density = np.zeros((N_SITES + 1, T), dtype=float)
-        for _, row in strain_df.iterrows():
-            i = step_to_idx[int(row["Step"])]
-            s = int(row["strain"])
-            density[bits_in_common[s], i] += float(row["count"])
+        np.add.at(density, (bic_arr, step_idx_arr), counts_arr)
+
+        # Normalize each column so values represent the proportion of
+        # *circulating* strains rather than the host-population
+        # fraction. Steps with no infections leave the column at zero.
+        col_totals = density.sum(axis=0, keepdims=True)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            density = np.where(col_totals > 0, density / col_totals, 0.0)
+
+        base_cmap = plt.get_cmap(cmap)
+        trunc_cmap = mcolors.LinearSegmentedColormap.from_list(
+            f"{cmap}_trunc",
+            base_cmap(np.linspace(0.2, 1.0, 256)),
+        )
+        trunc_cmap.set_bad("white")
+        masked_density = np.ma.masked_equal(density, 0.0)
 
         with tp.teed(
             plt.subplots,
@@ -1558,13 +1600,13 @@ def def_make_density_heatmap_plot(np, pathlib, plt, sns, tp):
             teeplot_subdir=pathlib.Path(__file__).stem,
         ) as (fig, ax):
             # origin="lower" places density[0, :] (bits_in_common = 0,
-            # i.e. complement of end-state strain) at the bottom and
+            # complement of end-state strain) at the bottom and
             # density[N_SITES, :] (identical with end-state) at the top.
             im = ax.imshow(
-                density,
+                masked_density,
                 origin="lower",
                 aspect="auto",
-                cmap=cmap,
+                cmap=trunc_cmap,
                 extent=[
                     float(unique_steps.min()) - 0.5,
                     float(unique_steps.max()) + 0.5,
@@ -1580,7 +1622,7 @@ def def_make_density_heatmap_plot(np, pathlib, plt, sns, tp):
                 f"{end_strain:0{N_SITES}b}"
             )
             cbar = fig.colorbar(im, ax=ax, pad=0.02)
-            cbar.set_label("Population fraction")
+            cbar.set_label("Fraction of circulating strains")
             sns.despine(ax=ax)
 
     return (make_density_heatmap_plot,)
@@ -1608,7 +1650,18 @@ def run_phylogeny_sweep(
     uuid,
 ):
     PHYLO_MUTATION_RATE = 1e-5
-    POW_ = POW
+
+    # Sweep conditions: (N_SITES, pow). Low-N_SITES rows reuse the CLI
+    # `pow` value; the 8- and 16-site rows tune `pow` down to keep the
+    # R0-like quantity in a comparable range when more sites multiply
+    # the per-strain susceptibility product.
+    PHYLO_CONDITIONS = (
+        (2, POW),
+        (3, POW),
+        (4, POW),
+        (8, 0.5),
+        (16, 0.25),
+    )
 
     nbname = pathlib.Path(__file__).stem
     out_dir = pathlib.Path("outdata") / nbname
@@ -1628,11 +1681,17 @@ def run_phylogeny_sweep(
     phylo_chunks = []
 
     for _seed in range(1, N_REPLICATES + 1):
-        for PHYLO_N_SITES in (2, 3, 4):
+        for PHYLO_N_SITES, POW_ in PHYLO_CONDITIONS:
+            n_strains_ = 1 << PHYLO_N_SITES
+            # 16- and 65k-strain panels are infeasible for per-strain
+            # plots that draw one line per strain or build an
+            # n_strains x n_strains adjacency matrix; gate them off so
+            # the heatmap and other aggregate plots still render.
+            do_per_strain_plots = n_strains_ <= 16
             replicate_uid = uuid.uuid4().hex
             print(
                 f"=== seed={_seed} N_SITES={PHYLO_N_SITES} "
-                f"uid={replicate_uid} ===",
+                f"pow={POW_} uid={replicate_uid} ===",
             )
             CONTACT_RATE_ = 0.35
             RECOVERY_RATE_ = 0.1
@@ -1682,20 +1741,21 @@ def run_phylogeny_sweep(
                 print("  (SKIP_PLOTTING=True — skipping strain curves)")
             else:
                 for palette in "husl", "hls", "Set2":
-                    make_strain_curves_plot(
-                        PHYLO_N_SITES,
-                        _phylo_df,
-                        _strain_df,
-                        palette=palette,
-                        teeplot_outattrs={
-                            "a": "strain-curves",
-                            "n_sites": PHYLO_N_SITES,
-                            "n_steps": int(_phylo_df["Step"].max()) + 1,
-                            "replicate": _seed,
-                            "palette": palette,
-                            "pow": POW_,
-                        },
-                    )
+                    if do_per_strain_plots:
+                        make_strain_curves_plot(
+                            PHYLO_N_SITES,
+                            _phylo_df,
+                            _strain_df,
+                            palette=palette,
+                            teeplot_outattrs={
+                                "a": "strain-curves",
+                                "n_sites": PHYLO_N_SITES,
+                                "n_steps": int(_phylo_df["Step"].max()) + 1,
+                                "replicate": _seed,
+                                "palette": palette,
+                                "pow": POW_,
+                            },
+                        )
                     make_allele_curves_plot(
                         PHYLO_N_SITES,
                         _phylo_df,
@@ -1710,20 +1770,21 @@ def run_phylogeny_sweep(
                             "pow": POW_,
                         },
                     )
-                    make_r_curves_plot(
-                        PHYLO_N_SITES,
-                        _strain_df,
-                        RECOVERY_RATE=RECOVERY_RATE_,
-                        palette=palette,
-                        teeplot_outattrs={
-                            "a": "r-curves",
-                            "n_sites": PHYLO_N_SITES,
-                            "n_steps": int(_phylo_df["Step"].max()) + 1,
-                            "replicate": _seed,
-                            "palette": palette,
-                            "pow": POW_,
-                        },
-                    )
+                    if do_per_strain_plots:
+                        make_r_curves_plot(
+                            PHYLO_N_SITES,
+                            _strain_df,
+                            RECOVERY_RATE=RECOVERY_RATE_,
+                            palette=palette,
+                            teeplot_outattrs={
+                                "a": "r-curves",
+                                "n_sites": PHYLO_N_SITES,
+                                "n_steps": int(_phylo_df["Step"].max()) + 1,
+                                "replicate": _seed,
+                                "palette": palette,
+                                "pow": POW_,
+                            },
+                        )
                 for cmap in "rocket_r", "viridis", "magma_r":
                     make_density_heatmap_plot(
                         PHYLO_N_SITES,
@@ -1749,6 +1810,10 @@ def run_phylogeny_sweep(
             for palette in "rocket_r", "tab20", "tab10":
                 if SKIP_PLOTTING:
                     print("  (SKIP_PLOTTING=True — skipping strain graph)")
+                elif not do_per_strain_plots:
+                    print(
+                        "  (n_strains too large — skipping strain graph)",
+                    )
                 else:
                     make_strain_graph_plot(
                         PHYLO_N_SITES,

--- a/bindle/2026-05-08-hamming-flamegraph.py
+++ b/bindle/2026-05-08-hamming-flamegraph.py
@@ -33,7 +33,8 @@ def import_pkg(warnings):
         import cupy as cp
     except ImportError:
         warnings.warn(
-            "cupy import failed; falling back to numpy " "(GPU engine unavailable)",
+            "cupy import failed; falling back to numpy "
+            "(GPU engine unavailable)",
             stacklevel=2,
         )
         import numpy as cp
@@ -129,7 +130,9 @@ def configure_args(mo):
 
 @app.cell
 def configure_backend(ENGINE, cp, np):
-    use_cupy = ENGINE == "cupy"  # use cupy backend (GPU), otherwise numpy (CPU)
+    use_cupy = (
+        ENGINE == "cupy"
+    )  # use cupy backend (GPU), otherwise numpy (CPU)
     xp = [np, cp][use_cupy]
     return (xp,)
 
@@ -278,7 +281,9 @@ def def_simulate(
         else:
             genome_dtype = xp.uint16
 
-        def initialize_pop() -> (Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]):
+        def initialize_pop() -> (
+            Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]
+        ):
             """Initialize population statuses, genomes, and immune history."""
             pathogen_genomes = xp.zeros(shape=POP_SIZE, dtype=genome_dtype)
             host_immunities = xp.full(
@@ -286,7 +291,9 @@ def def_simulate(
                 fill_value=0.0,
                 dtype=xp.float32,
             )
-            host_statuses = xp.full(shape=POP_SIZE, fill_value=0, dtype=xp.uint8)
+            host_statuses = xp.full(
+                shape=POP_SIZE, fill_value=0, dtype=xp.uint8
+            )
             pathogen_markers = xp.random.randint(
                 low=0,
                 high=2**63,
@@ -311,7 +318,9 @@ def def_simulate(
             pathogen_genomes: xp.ndarray,
         ) -> Tuple[xp.ndarray, xp.ndarray]:
             """Seed the initial infection wave with the starting strain."""
-            seeded_indices = xp.random.choice(POP_SIZE, size=SEED_COUNT, replace=False)
+            seeded_indices = xp.random.choice(
+                POP_SIZE, size=SEED_COUNT, replace=False
+            )
             host_statuses[seeded_indices] = 1
             pathogen_genomes[seeded_indices] = 0  # wildtype
             return host_statuses, pathogen_genomes
@@ -328,15 +337,17 @@ def def_simulate(
             pathogen_bits = (
                 pathogen_genomes[:, None] >> xp.arange(N_SITES, dtype=xp.uint8)
             ) & 1
-            pathogen_alleles = (pathogen_bits[:, :, None] == xp.array([0, 1])).reshape(
-                -1, 2 * N_SITES
-            )
+            pathogen_alleles = (
+                pathogen_bits[:, :, None] == xp.array([0, 1])
+            ).reshape(-1, 2 * N_SITES)
 
             # active_susc = xp.where(
             #     pathogen_alleles, host_susceptibilities, 1.0
             # )
             # res = xp.prod(active_susc, axis=1)
-            active_susc = xp.where(pathogen_alleles, host_susceptibilities, np.nan)
+            active_susc = xp.where(
+                pathogen_alleles, host_susceptibilities, np.nan
+            )
             res = xp.nanmean(active_susc, axis=1)
             assert res.shape == (POP_SIZE,)
             return xp.pow(res, pow)
@@ -348,7 +359,8 @@ def def_simulate(
                 pathogen_genomes: xp.ndarray,
             ) -> xp.ndarray:
                 pathogen_bits = (
-                    pathogen_genomes[:, None] >> xp.arange(N_SITES, dtype=xp.uint8)
+                    pathogen_genomes[:, None]
+                    >> xp.arange(N_SITES, dtype=xp.uint8)
                 ) & 1
 
                 imm_reshaped = xp.reshape(host_immunities, (-1, N_SITES, 2))
@@ -356,17 +368,19 @@ def def_simulate(
                 idx_curr = pathogen_bits[:, :, None]
                 idx_opp = 1 - idx_curr
 
-                imm_curr = xp.take_along_axis(imm_reshaped, idx_curr, axis=2).squeeze(
-                    axis=2
-                )
-                imm_opp = xp.take_along_axis(imm_reshaped, idx_opp, axis=2).squeeze(
-                    axis=2
-                )
+                imm_curr = xp.take_along_axis(
+                    imm_reshaped, idx_curr, axis=2
+                ).squeeze(axis=2)
+                imm_opp = xp.take_along_axis(
+                    imm_reshaped, idx_opp, axis=2
+                ).squeeze(axis=2)
 
                 host_immunity_deltas = imm_curr - imm_opp
 
                 b_values = 1.0 + within_host_b * host_immunity_deltas
-                b_values = xp.where(xp.abs(b_values - 1.0) < 1e-7, 1.000001, b_values)
+                b_values = xp.where(
+                    xp.abs(b_values - 1.0) < 1e-7, 1.000001, b_values
+                )
 
                 return (MUTATION_RATE / (b_values - 1.0)) * (
                     xp.exp((b_values - 1.0) * within_host_t) - 1.0
@@ -380,7 +394,8 @@ def def_simulate(
             ) -> xp.ndarray:
                 n_infected = host_immunities.shape[0]
                 return (
-                    xp.ones((n_infected, 1), dtype=MUTATION_RATE.dtype) * MUTATION_RATE
+                    xp.ones((n_infected, 1), dtype=MUTATION_RATE.dtype)
+                    * MUTATION_RATE
                 )
 
         def update_waning(host_immunities: xp.ndarray) -> xp.ndarray:
@@ -404,11 +419,13 @@ def def_simulate(
             pathogen_bits = (
                 pathogen_genomes[:, None] >> xp.arange(N_SITES, dtype=xp.uint8)
             ) & 1
-            pathogen_alleles = (pathogen_bits[:, :, None] == xp.array([0, 1])).reshape(
-                -1, 2 * N_SITES
-            )
+            pathogen_alleles = (
+                pathogen_bits[:, :, None] == xp.array([0, 1])
+            ).reshape(-1, 2 * N_SITES)
 
-            assert np.all(pathogen_alleles[recovered_mask].sum(axis=1) == N_SITES)
+            assert np.all(
+                pathogen_alleles[recovered_mask].sum(axis=1) == N_SITES
+            )
 
             host_immunities[
                 pathogen_alleles.astype(bool) & recovered_mask[:, None]
@@ -464,7 +481,9 @@ def def_simulate(
                 pathogen_genomes[mutation_mask],
             )
             mutator_n = host_statuses[:MUTATOR_HOSTS_N].sum()
-            mprobs[:mutator_n] = xp.minimum(mprobs[:mutator_n] * MUTATOR_HOSTS_MX, 1.0)
+            mprobs[:mutator_n] = xp.minimum(
+                mprobs[:mutator_n] * MUTATOR_HOSTS_MX, 1.0
+            )
 
             mprobs[mprobs < MUTATION_THRESHOLD] = 0.0
 
@@ -472,9 +491,9 @@ def def_simulate(
                 mutation_occurs = (
                     xp.random.rand(mprobs.shape[0]) < mprobs[:, s]
                 ).astype(genome_dtype)
-                pathogen_genomes[mutation_mask] ^= (mutation_occurs << s).astype(
-                    genome_dtype
-                )
+                pathogen_genomes[mutation_mask] ^= (
+                    mutation_occurs << s
+                ).astype(genome_dtype)
 
             return pathogen_genomes
 
@@ -577,7 +596,9 @@ def def_simulate(
                 ) & 1
                 hw_per_host = infected_bits.sum(axis=1).astype(xp.int64)
                 hw_counts_arr = xp.bincount(hw_per_host, minlength=N_SITES + 1)
-                hw_prevalences = [float(c) / POP_SIZE for c in hw_counts_arr.tolist()]
+                hw_prevalences = [
+                    float(c) / POP_SIZE for c in hw_counts_arr.tolist()
+                ]
 
                 strain_per_host = pathogen_genomes[inf_mask].astype(xp.int64)
                 _u_strains, _u_counts = xp.unique(
@@ -637,11 +658,15 @@ def def_simulate(
                     dtype=xp.int64,
                 )
                 _site_idx = xp.arange(N_SITES, dtype=xp.int64)
-                _strain_bits = (_observed_arr[:, None] >> _site_idx[None, :]) & 1
-                _strain_cols = (2 * _site_idx[None, :] + _strain_bits).astype(xp.int64)
-                host_susc_2d = (1.0 - (IMMUNE_STRENGTH * host_immunities)).reshape(
-                    POP_SIZE, 2 * N_SITES
+                _strain_bits = (
+                    _observed_arr[:, None] >> _site_idx[None, :]
+                ) & 1
+                _strain_cols = (2 * _site_idx[None, :] + _strain_bits).astype(
+                    xp.int64
                 )
+                host_susc_2d = (
+                    1.0 - (IMMUNE_STRENGTH * host_immunities)
+                ).reshape(POP_SIZE, 2 * N_SITES)
                 strain_susc_per_host = host_susc_2d[:, _strain_cols].prod(
                     axis=2,
                 )
@@ -649,7 +674,9 @@ def def_simulate(
                 strain_susc_per_host = (
                     strain_susc_per_host * (host_statuses == 0)[:, None]
                 )
-                expected_R_per_strain = strain_susc_per_host.mean(axis=0) * CONTACT_RATE
+                expected_R_per_strain = (
+                    strain_susc_per_host.mean(axis=0) * CONTACT_RATE
+                )
                 expected_R_dict = dict(
                     zip(
                         map(int, _observed_arr.tolist()),
@@ -1014,7 +1041,9 @@ def def_make_phylogeny_plot(
             sns.despine(ax=ax_hw, left=True, bottom=True, top=False)
 
             ax_hw.legend(
-                handles=[_hw_handle(w, label) for w, label in hw_legend_entries],
+                handles=[
+                    _hw_handle(w, label) for w, label in hw_legend_entries
+                ],
                 title="Hamming weight",
                 loc="center left",
                 bbox_to_anchor=(1.02, 0.5),
@@ -1075,10 +1104,14 @@ def def_make_strain_graph_plot(ig, iplotx, np, pathlib, plt, sns, tp):
         strains, counts = np.unique(genomes, return_counts=True)
         n_strains = int(strains.size)
         if n_strains < 2:
-            print(f"  (only {n_strains} strain --- skipping strain graph plot)")
+            print(
+                f"  (only {n_strains} strain --- skipping strain graph plot)"
+            )
             return
 
-        hamming_weights = np.array([bin(int(s)).count("1") for s in strains], dtype=int)
+        hamming_weights = np.array(
+            [bin(int(s)).count("1") for s in strains], dtype=int
+        )
 
         xor = strains[:, None] ^ strains[None, :]
         dists = np.zeros_like(xor, dtype=np.int32)
@@ -1101,7 +1134,9 @@ def def_make_strain_graph_plot(ig, iplotx, np, pathlib, plt, sns, tp):
             snapshots.append((n, dict(cumulative)))
 
         palette_colors = sns.color_palette(palette, N_SITES + 1)
-        node_facecolors = [(*palette_colors[int(hw)], 0.8) for hw in hamming_weights]
+        node_facecolors = [
+            (*palette_colors[int(hw)], 0.8) for hw in hamming_weights
+        ]
 
         max_count = int(counts.max())
         sizes = 4.0 + 18.0 * np.sqrt(counts / max_count)
@@ -1145,7 +1180,9 @@ def def_make_strain_graph_plot(ig, iplotx, np, pathlib, plt, sns, tp):
                 # for higher-n edges; n>1 edges drawn dashed to distinguish
                 # them from direct mutational neighbors.
                 widths = [3.0 / edges_dict[e] for e in edges]
-                linestyles = ["-" if edges_dict[e] == 1 else "--" for e in edges]
+                linestyles = [
+                    "-" if edges_dict[e] == 1 else "--" for e in edges
+                ]
 
                 g_plot = ig.Graph(n=n_strains)
                 if edges:
@@ -1328,7 +1365,9 @@ def def_make_allele_curves_plot(allele_palette, np, pathlib, plt, sns, tp):
         # over strains carrying that allele at that site.
         unique_steps = sorted(strain_df["Step"].unique())
         step_to_idx = {t: i for i, t in enumerate(unique_steps)}
-        prev_per_allele = np.zeros((len(unique_steps), N_SITES, 2), dtype=float)
+        prev_per_allele = np.zeros(
+            (len(unique_steps), N_SITES, 2), dtype=float
+        )
         for s in range(n_strains):
             sub = strain_df[strain_df["strain"] == s]
             for _, row in sub.iterrows():
@@ -1437,7 +1476,9 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
         """
         n_strains = 1 << N_SITES
 
-        unique_steps = np.array(sorted(strain_df["Step"].unique()), dtype=float)
+        unique_steps = np.array(
+            sorted(strain_df["Step"].unique()), dtype=float
+        )
         T = len(unique_steps)
         step_to_idx = {t: i for i, t in enumerate(unique_steps.tolist())}
 
@@ -1505,7 +1546,9 @@ def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
                     linewidth=1.5,
                     label=label,
                 )
-            ax_expected.axhline(1.0, color="gray", linestyle=":", linewidth=0.8)
+            ax_expected.axhline(
+                1.0, color="gray", linestyle=":", linewidth=0.8
+            )
             ax_expected.set_ylabel("expected R")
             ax_expected.set_ylim(bottom=0.0)
             sns.despine(ax=ax_expected)
@@ -1569,7 +1612,9 @@ def def_make_density_heatmap_plot(np, pathlib, plt, sns, tp):
         """
         n_strains = 1 << N_SITES
 
-        unique_steps = np.array(sorted(strain_df["Step"].unique()), dtype=np.int64)
+        unique_steps = np.array(
+            sorted(strain_df["Step"].unique()), dtype=np.int64
+        )
         T = len(unique_steps)
         final_step = int(unique_steps.max())
 
@@ -1633,7 +1678,8 @@ def def_make_density_heatmap_plot(np, pathlib, plt, sns, tp):
             ax.set_yticks(np.arange(N_SITES + 1))
             ax.set_xlabel("Time")
             ax.set_ylabel(
-                "bits in common with\nend-state strain " f"{end_strain:0{N_SITES}b}"
+                "bits in common with\nend-state strain "
+                f"{end_strain:0{N_SITES}b}"
             )
             cbar = fig.colorbar(im, ax=ax, pad=0.02)
             cbar.set_label("Fraction of circulating strains")
@@ -1658,7 +1704,9 @@ def _(np, pathlib, pd, sns, tp, warnings):
         """
         n_strains = 1 << N_SITES
 
-        unique_steps = np.array(sorted(strain_df["Step"].unique()), dtype=np.int64)
+        unique_steps = np.array(
+            sorted(strain_df["Step"].unique()), dtype=np.int64
+        )
         T = len(unique_steps)
         final_step = int(unique_steps.max())
 
@@ -1701,7 +1749,9 @@ def _(np, pathlib, pd, sns, tp, warnings):
         # 4. Construct explicit bin edges and convert to LIST to prevent Seaborn array evaluation bug
         if len(unique_steps) > 1:
             half_step = (unique_steps[1] - unique_steps[0]) / 2.0
-            np.append(unique_steps - half_step, unique_steps[-1] + half_step).tolist()
+            np.append(
+                unique_steps - half_step, unique_steps[-1] + half_step
+            ).tolist()
         else:
             strain_df["Step"].max() + 1  # Fallback
 
@@ -2037,11 +2087,19 @@ def run_phylogeny_sweep(
             gc.collect()
 
     traj_df_all = (
-        pd.concat(traj_chunks, ignore_index=True) if traj_chunks else pd.DataFrame()
+        pd.concat(traj_chunks, ignore_index=True)
+        if traj_chunks
+        else pd.DataFrame()
     )
-    hw_df_all = pd.concat(hw_chunks, ignore_index=True) if hw_chunks else pd.DataFrame()
+    hw_df_all = (
+        pd.concat(hw_chunks, ignore_index=True)
+        if hw_chunks
+        else pd.DataFrame()
+    )
     strain_df_all = (
-        pd.concat(strain_chunks, ignore_index=True) if strain_chunks else pd.DataFrame()
+        pd.concat(strain_chunks, ignore_index=True)
+        if strain_chunks
+        else pd.DataFrame()
     )
     records_df_all = (
         pd.concat(records_chunks, ignore_index=True)
@@ -2049,7 +2107,9 @@ def run_phylogeny_sweep(
         else pd.DataFrame()
     )
     phylo_df_all = (
-        pd.concat(phylo_chunks, ignore_index=True) if phylo_chunks else pd.DataFrame()
+        pd.concat(phylo_chunks, ignore_index=True)
+        if phylo_chunks
+        else pd.DataFrame()
     )
 
     traj_path = out_dir / f"a=traj+what={nbname}+ext=.pqt"
@@ -2065,7 +2125,9 @@ def run_phylogeny_sweep(
     print(f"wrote trajectory parquet ({len(traj_df_all)} rows): {traj_path}")
     print(f"wrote hw parquet ({len(hw_df_all)} rows): {hw_path}")
     print(f"wrote strain parquet ({len(strain_df_all)} rows): {strain_path}")
-    print(f"wrote records parquet ({len(records_df_all)} rows): {records_path}")
+    print(
+        f"wrote records parquet ({len(records_df_all)} rows): {records_path}"
+    )
     print(f"wrote phylogeny parquet ({len(phylo_df_all)} rows): {phylo_path}")
     return
 

--- a/bindle/2026-05-08-hamming-flamegraph.py
+++ b/bindle/2026-05-08-hamming-flamegraph.py
@@ -1,0 +1,2079 @@
+import marimo
+
+__generated_with = "0.23.2"
+app = marimo.App(width="full")
+
+
+@app.cell
+def import_std():
+    import gc
+    import pathlib
+    import random
+    from typing import Dict, List, Sequence, Tuple, Union
+    import uuid
+    import warnings
+
+    return (
+        Dict,
+        List,
+        Sequence,
+        Tuple,
+        Union,
+        gc,
+        pathlib,
+        random,
+        uuid,
+        warnings,
+    )
+
+
+@app.cell
+def import_pkg(warnings):
+    try:
+        import cupy as cp
+    except ImportError:
+        warnings.warn(
+            "cupy import failed; falling back to numpy " "(GPU engine unavailable)",
+            stacklevel=2,
+        )
+        import numpy as cp
+
+    # workaround: iplotx 1.7.x uses importlib.metadata without importing it
+    import importlib.metadata  # noqa: F401
+
+    import downstream.dstream as dstream
+    import hstrat
+    import igraph as ig
+    import iplotx
+    import marimo as mo
+    import matplotlib.pyplot as plt
+    from matplotlib.ticker import FuncFormatter, MaxNLocator
+    import numpy as np
+    import pandas as pd
+    from phyloframe import legacy as pfl
+    import polars as pl
+    import seaborn as sns
+    from teeplot import teeplot as tp
+    from tqdm.auto import tqdm
+    from watermark import watermark
+
+    from pylib import allele_palette, draw_scatter_tree, strain_palette
+
+    return (
+        FuncFormatter,
+        MaxNLocator,
+        allele_palette,
+        cp,
+        draw_scatter_tree,
+        dstream,
+        hstrat,
+        ig,
+        iplotx,
+        mo,
+        np,
+        pd,
+        pfl,
+        pl,
+        plt,
+        sns,
+        strain_palette,
+        tp,
+        tqdm,
+        watermark,
+    )
+
+
+@app.cell(hide_code=True)
+def do_watermark(mo, watermark):
+    mo.md(
+        f"""
+    ```Text
+    {watermark(
+        current_date=True,
+        iso8601=True,
+        machine=True,
+        updated=True,
+        python=True,
+        iversions=True,
+        globals_=globals(),
+    )}
+    ```
+    """
+    )
+    return
+
+
+@app.cell
+def configure_args(mo):
+    # Marimo CLI args (set via `marimo edit notebook.py -- --pop-size N ...`
+    # or `marimo export ipynb ... -- --pop-size N ...`). Defaults match the
+    # current sweep settings: POP_SIZE=200_000 hosts and N_STEPS=100 steps.
+    _args = mo.cli_args()
+    POP_SIZE = int(_args.get("pop-size") or 100_000)
+    POW = float(_args.get("pow") or 1.0)
+    N_STEPS = int(_args.get("n-steps") or 1_200)
+    N_REPLICATES = int(_args.get("n-replicates") or 1)
+    ENGINE = str(_args.get("engine") or "numpy").lower()
+    if ENGINE not in ("numpy", "cupy"):
+        raise ValueError(
+            f"engine must be 'numpy' or 'cupy', got {ENGINE!r}",
+        )
+    SKIP_PLOTTING = bool(_args.get("skip-plotting") or False)
+    print(
+        f"args: POP_SIZE={POP_SIZE} N_STEPS={N_STEPS} "
+        f"N_REPLICATES={N_REPLICATES} ENGINE={ENGINE} "
+        f"SKIP_PLOTTING={SKIP_PLOTTING}",
+    )
+    return ENGINE, N_REPLICATES, N_STEPS, POP_SIZE, POW, SKIP_PLOTTING
+
+
+@app.cell
+def configure_backend(ENGINE, cp, np):
+    use_cupy = ENGINE == "cupy"  # use cupy backend (GPU), otherwise numpy (CPU)
+    xp = [np, cp][use_cupy]
+    return (xp,)
+
+
+@app.cell(hide_code=True)
+def delimit_simulation(mo):
+    mo.md(
+        """
+    ## Simulation Implementation
+
+    This notebook is an R-per-strain companion to
+    `2026-05-03-allele-abm-strain-curves.py`: the low-`N_SITES` rows
+    of the sweep (`2, 3, 4`) keep the strain count
+    `2**N_SITES <= 16` so that per-strain prevalence and per-strain
+    population-average susceptibility can be tracked by individual
+    strain. The sweep is extended with two high-`N_SITES` rows
+    (`(N_SITES, pow) = (8, 0.5), (16, 0.25)`) for which the
+    per-strain stack-plot, R-curves, and strain-graph panels are
+    skipped (one line/node per strain is unreadable, and the dense
+    `(POP_SIZE, n_strains, N_SITES)` susceptibility tensor used for
+    expected-R is gated off above a memory cap). The Hamming-distance
+    density heatmap aggregates only `N_SITES + 1` bins, so it
+    continues to render at 8 and 16 sites.
+
+    In addition to the phylogeny-and-strain-network plots
+    inherited from the 32-site notebook, this notebook renders an
+    "r-curves" figure: a multi-row stack with the *expected* per-
+    strain reproduction number on the very top row by itself, and
+    the *actual* per-strain reproduction number on subsequent
+    rows at increasing rolling-mean windows (unsmoothed first). Both
+    per-step rates are scaled by the discrete-time R0 multiplier
+    `(1 - RECOVERY_RATE) / RECOVERY_RATE` so the plotted values are
+    the expected total infections caused by a single primary (an
+    `R0`-like quantity) rather than the per-step rate, and `R = 1`
+    is drawn as the epidemic-threshold reference line. The factor
+    is `(1 - p) / p` rather than `1 / p` because
+    `update_recoveries` runs after `transmit_infection` within the
+    same step, so a primary newly infected in step `t` faces an
+    immediate recovery check before participating as a source at
+    step `t+1`; the expected number of future transmit-as-source
+    steps is `sum_{k=1}^inf (1 - p)^k = (1 - p) / p` (off-by-one if
+    you forget the within-step recovery).
+
+    * `R_actual(t, s) = new_infections(s, t) /
+      n_with_strain(s, t) * (1 - RECOVERY_RATE) / RECOVERY_RATE` --
+      new strain-`s` infections caused per current strain-`s`
+      infected per step, multiplied by the R0 multiplier, computed
+      from instrumentation logged inside `simulate()`.
+      `new_infections` is captured pre-mutation in
+      `update_simulation()` so the strain label reflects the strain
+      that actually transmitted, not its post-mutation descendant.
+
+    * `R_expected(t, s) = R_expected_per_step(s, t) *
+      (1 - RECOVERY_RATE) / RECOVERY_RATE`, where
+      `R_expected_per_step(s, t)` is the average over the population
+      of the probability that strain `s` infects a randomly-sampled
+      individual on a single contact in one step. Currently-infected
+      hosts contribute zero since they cannot be re-infected --- the
+      `(host_statuses == 0)` mask zeros out their per-host
+      susceptibilities before averaging over the full `POP_SIZE`, so
+      the mean already accounts for the susceptible-only fraction.
+      The per-step quantity is logged as `strain_df["expected_R"]`
+      alongside `count` and `new_infections`; multiplying by the
+      R0 multiplier gives the analog of `R0`.
+
+    Phylogeny estimation still uses *hereditary stratigraphic surface*
+    annotations (see https://hstrat.rtfd.io). Each infected host carries
+    a `dstream_S=64`-site, 1-bit "hybrid" surface; the donor surface
+    state is copied to the recipient on transmission (the ABM analogue
+    of `CloneDescendant`). Per-step Hamming-weight prevalence and
+    per-strain prevalence are both logged as long-form dataframes (one
+    row per `(Step, hw)` and `(Step, strain)`).
+
+    The vectorized deposit pattern is adapted from
+    https://github.com/mmore500/hstrat-synthesis (see `pylib/track_ca.py`).
+    """
+    )
+    return
+
+
+@app.cell
+def def_simulate(
+    Dict,
+    List,
+    Sequence,
+    Tuple,
+    Union,
+    dstream,
+    gc,
+    np,
+    pd,
+    pl,
+    random,
+    tqdm,
+    xp,
+):
+    def simulate(
+        N_SITES: int = 2,
+        POP_SIZE: int = 1_000_000,
+        CONTACT_RATE: float = 0.3,
+        RECOVERY_RATE: float = 0.1,
+        MUTATION_RATE: Union[float, Sequence[float]] = 1e-4,
+        WANING_RATE: float = 0.02,
+        IMMUNE_STRENGTH: float = 0.9,
+        N_STEPS: int = 1_000,
+        SEED_COUNT: int = 10,
+        within_host_b: float = 0.2,
+        within_host_t: float = 25.0,
+        seed: int = 1,
+        MUTATOR_HOSTS_N: int = 0,
+        MUTATOR_HOSTS_MX: float = 1.0,
+        MUTATION_THRESHOLD: float = 0.0,
+        IMMUNITY_CEILING: float = 1.0,
+        IMMUNITY_FLOOR: float = 0.0,
+        track_phylogeny: bool = False,
+        DSTREAM_S: int = 64,
+        DSTREAM_ALGO=None,
+        N_SAMPLE: int = 2000,
+        pow: float = 1.0,
+    ) -> Union[
+        Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame],
+        Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame],
+    ]:
+        from collections import Counter
+
+        random.seed(seed)
+        np.random.seed(seed)
+        xp.random.seed(seed)
+
+        if DSTREAM_ALGO is None:
+            DSTREAM_ALGO = dstream.hybrid_0_steady_1_tilted_2_algo
+
+        MUTATION_RATE = xp.asarray(MUTATION_RATE, dtype=xp.float32)
+
+        # Pick the smallest unsigned int dtype that holds `N_SITES` bits.
+        # 16/32/64-site sweeps round-trip through uint16/uint32/uint64
+        # without truncation; >64 would need a custom multi-word genome.
+        if N_SITES > 64:
+            raise NotImplementedError(
+                "current data types support only up to 64 sites",
+            )
+        elif N_SITES > 32:
+            genome_dtype = xp.uint64
+        elif N_SITES > 16:
+            genome_dtype = xp.uint32
+        else:
+            genome_dtype = xp.uint16
+
+        def initialize_pop() -> (Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]):
+            """Initialize population statuses, genomes, and immune history."""
+            pathogen_genomes = xp.zeros(shape=POP_SIZE, dtype=genome_dtype)
+            host_immunities = xp.full(
+                shape=(POP_SIZE, 2 * N_SITES),
+                fill_value=0.0,
+                dtype=xp.float32,
+            )
+            host_statuses = xp.full(shape=POP_SIZE, fill_value=0, dtype=xp.uint8)
+            pathogen_markers = xp.random.randint(
+                low=0,
+                high=2**63,
+                size=POP_SIZE,
+                dtype=xp.int64,
+            ).astype(xp.uint64)
+            pathogen_markers |= xp.random.randint(
+                low=0,
+                high=2,
+                size=POP_SIZE,
+                dtype=xp.uint64,
+            ) << xp.uint64(63)
+            return (
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+            )
+
+        def infect_initial(
+            host_statuses: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+        ) -> Tuple[xp.ndarray, xp.ndarray]:
+            """Seed the initial infection wave with the starting strain."""
+            seeded_indices = xp.random.choice(POP_SIZE, size=SEED_COUNT, replace=False)
+            host_statuses[seeded_indices] = 1
+            pathogen_genomes[seeded_indices] = 0  # wildtype
+            return host_statuses, pathogen_genomes
+
+        def calc_infection_probabilities(
+            host_immunities: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+        ) -> xp.ndarray:
+            host_susceptibilities = xp.reshape(
+                1.0 - (IMMUNE_STRENGTH * host_immunities),
+                (POP_SIZE, 2 * N_SITES),
+            )
+
+            pathogen_bits = (
+                pathogen_genomes[:, None] >> xp.arange(N_SITES, dtype=xp.uint8)
+            ) & 1
+            pathogen_alleles = (pathogen_bits[:, :, None] == xp.array([0, 1])).reshape(
+                -1, 2 * N_SITES
+            )
+
+            # active_susc = xp.where(
+            #     pathogen_alleles, host_susceptibilities, 1.0
+            # )
+            # res = xp.prod(active_susc, axis=1)
+            active_susc = xp.where(pathogen_alleles, host_susceptibilities, np.nan)
+            res = xp.nanmean(active_susc, axis=1)
+            assert res.shape == (POP_SIZE,)
+            return xp.pow(res, pow)
+
+        if MUTATION_RATE.size == 1:
+
+            def calc_mutation_probabilities(
+                host_immunities: xp.ndarray,
+                pathogen_genomes: xp.ndarray,
+            ) -> xp.ndarray:
+                pathogen_bits = (
+                    pathogen_genomes[:, None] >> xp.arange(N_SITES, dtype=xp.uint8)
+                ) & 1
+
+                imm_reshaped = xp.reshape(host_immunities, (-1, N_SITES, 2))
+
+                idx_curr = pathogen_bits[:, :, None]
+                idx_opp = 1 - idx_curr
+
+                imm_curr = xp.take_along_axis(imm_reshaped, idx_curr, axis=2).squeeze(
+                    axis=2
+                )
+                imm_opp = xp.take_along_axis(imm_reshaped, idx_opp, axis=2).squeeze(
+                    axis=2
+                )
+
+                host_immunity_deltas = imm_curr - imm_opp
+
+                b_values = 1.0 + within_host_b * host_immunity_deltas
+                b_values = xp.where(xp.abs(b_values - 1.0) < 1e-7, 1.000001, b_values)
+
+                return (MUTATION_RATE / (b_values - 1.0)) * (
+                    xp.exp((b_values - 1.0) * within_host_t) - 1.0
+                )
+
+        else:
+
+            def calc_mutation_probabilities(
+                host_immunities: xp.ndarray,
+                pathogen_genomes: xp.ndarray,
+            ) -> xp.ndarray:
+                n_infected = host_immunities.shape[0]
+                return (
+                    xp.ones((n_infected, 1), dtype=MUTATION_RATE.dtype) * MUTATION_RATE
+                )
+
+        def update_waning(host_immunities: xp.ndarray) -> xp.ndarray:
+            host_immunities *= 1.0 - WANING_RATE
+            host_immunities[host_immunities > 0] = xp.clip(
+                host_immunities[host_immunities > 0],
+                IMMUNITY_FLOOR,
+                IMMUNITY_CEILING,
+            )
+            return host_immunities
+
+        def update_recoveries(
+            host_statuses: xp.ndarray,
+            host_immunities: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+        ) -> Tuple[xp.ndarray, xp.ndarray]:
+            recovered_mask = (host_statuses >= 1) * xp.random.rand(
+                POP_SIZE
+            ) > 1 - RECOVERY_RATE
+
+            pathogen_bits = (
+                pathogen_genomes[:, None] >> xp.arange(N_SITES, dtype=xp.uint8)
+            ) & 1
+            pathogen_alleles = (pathogen_bits[:, :, None] == xp.array([0, 1])).reshape(
+                -1, 2 * N_SITES
+            )
+
+            assert np.all(pathogen_alleles[recovered_mask].sum(axis=1) == N_SITES)
+
+            host_immunities[
+                pathogen_alleles.astype(bool) & recovered_mask[:, None]
+            ] = 1.0
+
+            host_statuses += (host_statuses > 0).astype(xp.uint8)
+            host_statuses[recovered_mask] = 0
+
+            return host_statuses, host_immunities
+
+        def transmit_infection(
+            host_statuses: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+            host_immunities: xp.ndarray,
+            pathogen_markers: xp.ndarray,
+        ) -> Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]:
+            contacts = xp.random.randint(
+                low=0, high=POP_SIZE, size=POP_SIZE, dtype=xp.uint32
+            )
+            inf_probs = (
+                calc_infection_probabilities(
+                    host_immunities, pathogen_genomes[contacts]
+                )
+                * (host_statuses == 0)
+                * (host_statuses[contacts] > 0)
+                * CONTACT_RATE
+            )
+
+            new_infections = xp.random.rand(POP_SIZE) < inf_probs
+            host_statuses[new_infections] = 1
+            pathogen_genomes[new_infections] = pathogen_genomes[contacts][
+                new_infections
+            ]
+            pathogen_markers[new_infections] = pathogen_markers[contacts][
+                new_infections
+            ]
+
+            return (
+                host_statuses,
+                pathogen_genomes,
+                pathogen_markers,
+                new_infections,
+            )
+
+        def apply_mutations(
+            pathogen_genomes: xp.ndarray,
+            host_statuses: xp.ndarray,
+        ) -> xp.ndarray:
+            mutation_mask = (host_statuses == 1).astype(bool)
+
+            mprobs = calc_mutation_probabilities(
+                host_immunities[mutation_mask],
+                pathogen_genomes[mutation_mask],
+            )
+            mutator_n = host_statuses[:MUTATOR_HOSTS_N].sum()
+            mprobs[:mutator_n] = xp.minimum(mprobs[:mutator_n] * MUTATOR_HOSTS_MX, 1.0)
+
+            mprobs[mprobs < MUTATION_THRESHOLD] = 0.0
+
+            for s in range(N_SITES):
+                mutation_occurs = (
+                    xp.random.rand(mprobs.shape[0]) < mprobs[:, s]
+                ).astype(genome_dtype)
+                pathogen_genomes[mutation_mask] ^= (mutation_occurs << s).astype(
+                    genome_dtype
+                )
+
+            return pathogen_genomes
+
+        def deposit_strata(
+            pathogen_markers: xp.ndarray,
+            t: int,
+        ) -> xp.ndarray:
+            site = DSTREAM_ALGO.assign_storage_site(DSTREAM_S, t + DSTREAM_S)
+            if site is None:
+                return pathogen_markers
+            new_bits = xp.random.randint(
+                0,
+                2,
+                size=POP_SIZE,
+                dtype=xp.uint64,
+            )
+            pathogen_markers ^= new_bits << np.uint64(63 - site)
+            return pathogen_markers
+
+        def update_simulation(
+            host_statuses: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+            host_immunities: xp.ndarray,
+            pathogen_markers: xp.ndarray,
+            t: int,
+        ) -> Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]:
+            (
+                host_statuses,
+                pathogen_genomes,
+                pathogen_markers,
+                new_infections,
+            ) = transmit_infection(
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+            )
+            new_strain_genomes = pathogen_genomes[new_infections].copy()
+            pathogen_genomes = apply_mutations(pathogen_genomes, host_statuses)
+            host_statuses, host_immunities = update_recoveries(
+                host_statuses, host_immunities, pathogen_genomes
+            )
+            host_immunities = update_waning(host_immunities)
+            pathogen_markers = deposit_strata(pathogen_markers, t)
+
+            return (
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+                new_strain_genomes,
+            )
+
+        (
+            host_statuses,
+            pathogen_genomes,
+            host_immunities,
+            pathogen_markers,
+        ) = initialize_pop()
+        host_statuses, pathogen_genomes = infect_initial(
+            host_statuses, pathogen_genomes
+        )
+        data_log: List[Dict[str, float]] = []
+        hw_log: List[Dict[str, float]] = []
+
+        # Per-step strain tracking uses sparse Counters over strains
+        # actually present (counts circulating + new infections) plus a
+        # global `observed_strains` set. The dense (Step, strain) rows
+        # are materialized after the loop via `counter.get(s, 0)` over
+        # the observed set --- avoiding O(N_STEPS * 2**N_SITES) memory
+        # that breaks the high-N_SITES sweeps.
+        strain_counters: List[Counter] = []
+        new_strain_counters: List[Counter] = []
+        expected_R_dicts: List[Dict[int, float]] = []
+        observed_strains: set = set()
+
+        for t in tqdm(range(N_STEPS), mininterval=20.0):
+            (
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+                new_strain_genomes,
+            ) = update_simulation(
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+                t,
+            )
+
+            inf_mask = host_statuses > 0
+            hw_prevalences: List[float] = [0.0] * (N_SITES + 1)
+            strain_counter: Counter = Counter()
+
+            if xp.any(inf_mask):
+                infected_bits = (
+                    pathogen_genomes[inf_mask, None]
+                    >> xp.arange(N_SITES, dtype=xp.uint8)
+                ) & 1
+                hw_per_host = infected_bits.sum(axis=1).astype(xp.int64)
+                hw_counts_arr = xp.bincount(hw_per_host, minlength=N_SITES + 1)
+                hw_prevalences = [float(c) / POP_SIZE for c in hw_counts_arr.tolist()]
+
+                strain_per_host = pathogen_genomes[inf_mask].astype(xp.int64)
+                _u_strains, _u_counts = xp.unique(
+                    strain_per_host,
+                    return_counts=True,
+                )
+                strain_counter = Counter(
+                    dict(
+                        zip(
+                            map(int, _u_strains.tolist()),
+                            map(int, _u_counts.tolist()),
+                        ),
+                    ),
+                )
+
+            # Per-strain new infections this step (raw counts; divided
+            # by POP_SIZE when materializing strain_log post-loop).
+            # Captured pre-mutation in update_simulation so the strain
+            # label is the strain that actually transmitted.
+            new_strain_counter: Counter = Counter()
+            if new_strain_genomes.size > 0:
+                _n_strains, _n_counts = xp.unique(
+                    new_strain_genomes.astype(xp.int64),
+                    return_counts=True,
+                )
+                new_strain_counter = Counter(
+                    dict(
+                        zip(
+                            map(int, _n_strains.tolist()),
+                            map(int, _n_counts.tolist()),
+                        ),
+                    ),
+                )
+
+            observed_strains.update(strain_counter.keys())
+            observed_strains.update(new_strain_counter.keys())
+
+            # Per-strain expected R per current infected per step:
+            # average over the population of P(strain s infects a random
+            # individual in one step). Currently-infected hosts
+            # contribute 0 since they cannot be re-infected --- the
+            # `(host_statuses == 0)` mask zeros out their per-host
+            # entries before averaging over the full POP_SIZE, so the
+            # mean already accounts for the susceptible-only fraction.
+            # Multiplying by n(s, t) gives the expected number of new
+            # strain-s infections per step. We only compute it for the
+            # cumulative observed-strain set, since unobserved strains
+            # never get logged --- the (POP_SIZE, n_observed, N_SITES)
+            # tensor is gated by a memory cap; over the cap, the dict
+            # is empty and downstream rows fall back to 0.0 via .get().
+            expected_R_dict: Dict[int, float] = {}
+            n_observed = len(observed_strains)
+            _expected_R_tensor_bytes = POP_SIZE * n_observed * N_SITES * 4
+            if n_observed > 0 and _expected_R_tensor_bytes <= 2 * 1024**3:
+                _observed_arr = xp.asarray(
+                    sorted(observed_strains),
+                    dtype=xp.int64,
+                )
+                _site_idx = xp.arange(N_SITES, dtype=xp.int64)
+                _strain_bits = (_observed_arr[:, None] >> _site_idx[None, :]) & 1
+                _strain_cols = (2 * _site_idx[None, :] + _strain_bits).astype(xp.int64)
+                host_susc_2d = (1.0 - (IMMUNE_STRENGTH * host_immunities)).reshape(
+                    POP_SIZE, 2 * N_SITES
+                )
+                strain_susc_per_host = host_susc_2d[:, _strain_cols].prod(
+                    axis=2,
+                )
+                strain_susc_per_host = xp.power(strain_susc_per_host, pow)
+                strain_susc_per_host = (
+                    strain_susc_per_host * (host_statuses == 0)[:, None]
+                )
+                expected_R_per_strain = strain_susc_per_host.mean(axis=0) * CONTACT_RATE
+                expected_R_dict = dict(
+                    zip(
+                        map(int, _observed_arr.tolist()),
+                        map(float, expected_R_per_strain.tolist()),
+                    ),
+                )
+
+            for w, count in enumerate(hw_prevalences):
+                hw_log.append(
+                    {
+                        "Step": t,
+                        "Seed": seed,
+                        "hw": w,
+                        "count": count,
+                    }
+                )
+
+            strain_counters.append(strain_counter)
+            new_strain_counters.append(new_strain_counter)
+            expected_R_dicts.append(expected_R_dict)
+
+            avg_susc = xp.mean(
+                (1.0 - (IMMUNE_STRENGTH * host_immunities))
+                * (host_statuses == 0)[:, None],
+                axis=0,
+            )
+
+            immunity_dict = {}
+            for i in range(2 * N_SITES):
+                site = i // 2
+                bit = i % 2
+                immunity_dict[f"Susc_S{site}_B{bit}"] = float(avg_susc[i])
+
+            log_entry = {
+                "Step": t,
+                "Seed": seed,
+                "Total_Infected": float(xp.sum(inf_mask)) / POP_SIZE,
+            }
+            log_entry.update(immunity_dict)
+            data_log.append(log_entry)
+
+        # Materialize the dense (Step, observed_strain) rows from the
+        # per-step Counters and the global observed-strain set, using
+        # `.get(s, 0)` to fill in zeros for strains not present at a
+        # given step. Strains never observed across the whole run get
+        # no rows (downstream code reads from strain_df by strain id,
+        # so a missing strain is implicitly zero).
+        sorted_observed = sorted(observed_strains)
+        strain_log: List[Dict[str, float]] = []
+        for t in tqdm(range(N_STEPS)):
+            sc = strain_counters[t]
+            nc = new_strain_counters[t]
+            er = expected_R_dicts[t]
+            for s in sorted_observed:
+                strain_log.append(
+                    {
+                        "Step": t,
+                        "Seed": seed,
+                        "strain": s,
+                        "count": sc.get(s, 0) / POP_SIZE,
+                        "new_infections": nc.get(s, 0) / POP_SIZE,
+                        "expected_R": er.get(s, 0.0),
+                    }
+                )
+
+        df = pl.DataFrame(data_log).to_pandas().fillna(0)
+        hw_df = pl.DataFrame(hw_log).to_pandas()
+        strain_df = pl.DataFrame(strain_log).to_pandas()
+        if not track_phylogeny:
+            return df, hw_df, strain_df
+
+        algo_name = f"dstream.{DSTREAM_ALGO.__name__}"
+        S = DSTREAM_S
+        T_bitwidth = 32
+        bitwidth = 1
+        bytes_per_T = T_bitwidth // 8
+        bytes_per_storage = S * bitwidth // 8
+        bytes_per_row = bytes_per_T + bytes_per_storage
+        empty_records = pd.DataFrame(
+            {
+                "data_hex": pd.Series([], dtype=str),
+                "dstream_algo": pd.Series([], dtype=str),
+                "dstream_storage_bitoffset": pd.Series([], dtype="int64"),
+                "dstream_storage_bitwidth": pd.Series([], dtype="int64"),
+                "dstream_T_bitoffset": pd.Series([], dtype="int64"),
+                "dstream_T_bitwidth": pd.Series([], dtype="int64"),
+                "dstream_S": pd.Series([], dtype="int64"),
+                "extant": pd.Series([], dtype=bool),
+                "snapshot_step": pd.Series([], dtype="int64"),
+                "genome": pd.Series([], dtype="int64"),
+                "taxon_id": pd.Series([], dtype="int64"),
+            },
+        )
+        infected_idx = xp.where(host_statuses > 0)[0]
+        n_inf = int(infected_idx.size)
+        if n_inf == 0:
+            return df, hw_df, strain_df, empty_records
+
+        n_sample = min(N_SAMPLE, n_inf)
+        sampled = (
+            xp.random.choice(infected_idx, size=n_sample, replace=False)
+            if n_sample < n_inf
+            else infected_idx
+        )
+
+        # CUPY SUPPORT: Transfer to host if using GPU
+        _to_np = (lambda a: np.asarray(a)) if xp is np else (lambda a: a.get())
+        sampled_markers = _to_np(pathogen_markers[sampled])
+        sampled_genomes = _to_np(pathogen_genomes[sampled])
+        # Rank includes implicit predeposits
+        sampled_steps = np.full(n_sample, N_STEPS + DSTREAM_S, dtype=np.uint32)
+        sampled_taxon_ids = np.arange(n_sample, dtype=np.int64)
+
+        T_bytes_hex = sampled_steps.astype(">u4").tobytes().hex()
+        marker_bytes_hex = sampled_markers.astype(">u8").tobytes().hex()
+        data_hex = [
+            (
+                T_bytes_hex[i * bytes_per_T * 2 : (i + 1) * bytes_per_T * 2]
+                + marker_bytes_hex[
+                    i * bytes_per_storage * 2 : (i + 1) * bytes_per_storage * 2
+                ]
+            )
+            for i in range(n_sample)
+        ]
+
+        records_df = pd.DataFrame(
+            {
+                "data_hex": data_hex,
+                "dstream_algo": algo_name,
+                "dstream_storage_bitoffset": bytes_per_T * 8,
+                "dstream_storage_bitwidth": bytes_per_storage * 8,
+                "dstream_T_bitoffset": 0,
+                "dstream_T_bitwidth": T_bitwidth,
+                "dstream_S": S,
+                "extant": True,
+                "snapshot_step": sampled_steps.astype(np.int64),
+                "genome": sampled_genomes.astype(np.int64),
+                "taxon_id": sampled_taxon_ids,
+            }
+        )
+        assert all(len(h) == bytes_per_row * 2 for h in data_hex), (
+            f"hex length mismatch (expected {bytes_per_row * 2}, "
+            f"got {set(len(h) for h in data_hex)})"
+        )
+        del data_hex, T_bytes_hex, marker_bytes_hex
+        gc.collect()
+        return df, hw_df, strain_df, records_df
+
+    return (simulate,)
+
+
+@app.cell(hide_code=True)
+def delimit_reconstruct(mo):
+    mo.md(
+        """
+    ## Surface-Annotation Reconstruction
+
+    Given the snapshot records emitted by `simulate(..., track_phylogeny=
+    True)`, run `hstrat.dataframe.surface_unpack_reconstruct` followed by
+    `hstrat.dataframe.surface_postprocess_trie` to estimate the phylogenetic
+    tree. We use `AssignOriginTimeNodeRankTriePostprocessor(t0="dstream_S")`
+    so that origin times line up with simulation step numbers.
+    """
+    )
+    return
+
+
+@app.cell
+def def_reconstruct_phylogeny(gc, hstrat, pd, pl):
+    def reconstruct_phylogeny(
+        records_df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        in_df = pl.from_pandas(records_df)
+        post = hstrat.dataframe.surface_build_tree(
+            in_df,
+            trie_postprocessor=(
+                hstrat.phylogenetic_inference.AssignOriginTimeNodeRankTriePostprocessor(
+                    t0="dstream_S",
+                )
+            ),
+        ).to_pandas()
+        gc.collect()
+        for col in ("id", "ancestor_id"):
+            if col in post.columns:
+                post[col] = post[col].astype("int64")
+        post["extant"] = post["extant"].fillna(False).astype(bool)
+        for col in ("snapshot_step", "genome", "origin_time"):
+            if col in post.columns:
+                post[col] = pd.to_numeric(post[col], errors="coerce")
+        return post
+
+    return (reconstruct_phylogeny,)
+
+
+@app.cell(hide_code=True)
+def delimit_phylogeny(mo):
+    mo.md(
+        """
+    ## Surface-Reconstructed Phylogeny
+
+    Sweep `N_SITES` over a few values and render the surface-reconstructed
+    phylogeny next to the absolute-prevalence and Hamming-weight stackplots.
+    """
+    )
+    return
+
+
+@app.cell
+def def_make_phylogeny_plot(
+    FuncFormatter,
+    MaxNLocator,
+    draw_scatter_tree,
+    np,
+    pathlib,
+    pd,
+    pfl,
+    plt,
+    sns,
+    tp,
+):
+    def make_phylogeny_plot(
+        N_SITES: int,
+        phylo_df,
+        hw_df,
+        phylogeny_df,
+        max_tips: int = 10_000,
+        seed: int = 0,
+        palette: str = "rocket_r",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        pruned_df = (
+            pfl.alifestd_downsample_tips_uniform_asexual(
+                phylogeny_df,
+                n_downsample=max_tips,
+                seed=0,
+            )
+            .pipe(pfl.alifestd_add_global_root, root_attrs={"origin_time": 0})
+            .pipe(pfl.alifestd_collapse_unifurcations)
+            .pipe(pfl.alifestd_try_add_ancestor_list_col)
+            .pipe(pfl.alifestd_ladderize_asexual)
+            .pipe(pfl.alifestd_assign_contiguous_ids)
+        )
+        assert pfl.alifestd_validate(pruned_df)
+        print(f"  downsampled tree: {len(pruned_df)} nodes")
+        print(f"  leaf count: {pfl.alifestd_count_leaf_nodes(pruned_df)}")
+
+        pruned_df = pruned_df.assign(
+            hw=pruned_df["genome"].map(
+                lambda g: None if pd.isna(g) else bin(int(g)).count("1"),
+            ),
+        )
+        pruned_df = pruned_df.assign(
+            hw_label=pruned_df["hw"].map(
+                lambda w: None if pd.isna(w) else f"HW {int(w)}"
+            ),
+        )
+
+        hw_values = list(range(N_SITES + 1))
+        hw_palette = sns.color_palette(palette, len(hw_values))
+
+        present_hw = sorted(int(w) for w in hw_df["hw"].unique())
+        hw_labels = [f"HW {w}" for w in present_hw]
+        plot_df = hw_df.assign(
+            y=-hw_df["Step"],
+            hw_label=hw_df["hw"].map(lambda w: f"HW {int(w)}"),
+        )
+        plot_df = plot_df[plot_df["count"] > 0]
+
+        if len(present_hw) > 4:
+            _idx = np.unique(
+                np.linspace(0, len(present_hw) - 1, 4).round().astype(int)
+            ).tolist()
+        else:
+            _idx = list(range(len(present_hw)))
+        hw_legend_entries = [(present_hw[i], hw_labels[i]) for i in _idx]
+
+        def _hw_handle(w, label):
+            return plt.Line2D(
+                [0],
+                [0],
+                marker="s",
+                color="w",
+                markerfacecolor=hw_palette[w],
+                markersize=10,
+                label=label,
+            )
+
+        hw_palette_map = {f"HW {w}": hw_palette[w] for w in present_hw}
+
+        with tp.teed(
+            plt.subplots,
+            nrows=1,
+            ncols=3,
+            figsize=(8, 6),
+            gridspec_kw={
+                "width_ratios": [1.4, 1.0, 1.0],
+                "wspace": 0.1,
+            },
+            sharey=True,
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_tree, ax_strain, ax_hw = axes
+
+            sns.histplot(
+                data=plot_df,
+                y="y",
+                hue="hw_label",
+                hue_order=hw_labels,
+                weights="count",
+                binwidth=phylo_df["Step"].diff().min(),
+                multiple="stack",
+                stat="count",
+                element="poly",
+                palette=hw_palette_map,
+                ax=ax_strain,
+                fill=True,
+                linewidth=0,
+                legend=False,
+            )
+            _band_xs = [
+                c.get_paths()[0].vertices[:, 0].max()
+                for c in ax_strain.collections
+                if c.get_paths()
+            ]
+            if _band_xs:
+                _peak = max(_band_xs)
+                _lo, _ = ax_strain.get_xlim()
+                ax_strain.set_xlim(_lo, _peak * 1.05)
+
+            sns.kdeplot(
+                data=plot_df,
+                y="y",
+                hue="hw_label",
+                hue_order=hw_labels,
+                weights="count",
+                multiple="fill",
+                common_norm=True,
+                cut=0,
+                palette=hw_palette_map,
+                ax=ax_hw,
+                fill=True,
+                linewidth=0,
+                legend=False,
+                bw_adjust=0.5,
+            )
+
+            for ax in (ax_strain, ax_hw):
+                ax.set_xlabel("")
+            ax_hw.set_xlim(0, 1)
+
+            ax_tree.set_ylabel("step")
+            ax_tree.tick_params(left=True, labelleft=True)
+            for ax in (ax_strain, ax_hw):
+                ax.tick_params(labelleft=False, left=False)
+                ax.xaxis.tick_top()
+                ax.xaxis.set_label_position("top")
+
+            ax_tree.tick_params(bottom=False, labelbottom=False)
+            sns.despine(ax=ax_strain, left=True, bottom=True, top=False)
+            sns.despine(ax=ax_hw, left=True, bottom=True, top=False)
+
+            ax_hw.legend(
+                handles=[_hw_handle(w, label) for w, label in hw_legend_entries],
+                title="Hamming weight",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+            )
+
+            draw_scatter_tree(
+                pruned_df.reset_index(drop=True),
+                ax=ax_tree,
+                hue="hw_label",
+                scatter_kws=dict(
+                    legend=False,
+                    palette=hw_palette_map,
+                ),
+                tree_kws=dict(
+                    edge_color="gray",
+                    edge_linewidth=0.7,
+                    edge_zorder=1,
+                    ladderize=True,
+                ),
+            )
+            sns.despine(ax=ax_tree, top=True, right=True, bottom=True)
+            ax_tree.set_ylim(ax_hw.get_ylim())
+            ax_tree.set_aspect("auto")
+            ax_tree.yaxis.set_major_locator(MaxNLocator(integer=True))
+            ax_tree.yaxis.set_major_formatter(
+                FuncFormatter(lambda x, _: f"{abs(int(round(x)))}"),
+            )
+
+    return (make_phylogeny_plot,)
+
+
+@app.cell
+def def_make_strain_graph_plot(ig, iplotx, np, pathlib, plt, sns, tp):
+    def make_strain_graph_plot(
+        N_SITES: int,
+        records_df,
+        max_n: int = 4,
+        palette: str = "rocket_r",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Plot final-step strains as undirected graphs at thresholds n=1..max_n.
+
+        Nodes are unique strains (sized by population copies, colored by
+        Hamming weight, 80% alpha). Edges connect strains within Hamming
+        distance ``n``. For ``n > 1`` only edges that are not implicitly
+        present via a 2-hop path through previously-added edges are drawn,
+        with line thickness encoding the threshold ``n`` at which the edge
+        was introduced.
+        """
+        extant = records_df[records_df["extant"]].copy()
+        if len(extant) == 0:
+            print("  (no extant records --- skipping strain graph plot)")
+            return
+
+        genomes = extant["genome"].astype("int64").to_numpy()
+        strains, counts = np.unique(genomes, return_counts=True)
+        n_strains = int(strains.size)
+        if n_strains < 2:
+            print(f"  (only {n_strains} strain --- skipping strain graph plot)")
+            return
+
+        hamming_weights = np.array([bin(int(s)).count("1") for s in strains], dtype=int)
+
+        xor = strains[:, None] ^ strains[None, :]
+        dists = np.zeros_like(xor, dtype=np.int32)
+        tmp = xor.copy()
+        while tmp.any():
+            dists += (tmp & 1).astype(np.int32)
+            tmp >>= 1
+
+        cumulative = {}  # (i, j) with i < j -> threshold n at which added
+        adjacency = [set() for _ in range(n_strains)]
+        snapshots = []
+        for n in range(1, max_n + 1):
+            iu, ju = np.where(np.triu(dists == n, k=1))
+            for i, j in zip(iu.tolist(), ju.tolist()):
+                if n > 1 and adjacency[i] & adjacency[j]:
+                    continue
+                cumulative[(i, j)] = n
+                adjacency[i].add(j)
+                adjacency[j].add(i)
+            snapshots.append((n, dict(cumulative)))
+
+        palette_colors = sns.color_palette(palette, N_SITES + 1)
+        node_facecolors = [(*palette_colors[int(hw)], 0.8) for hw in hamming_weights]
+
+        max_count = int(counts.max())
+        sizes = 4.0 + 18.0 * np.sqrt(counts / max_count)
+
+        # Label only the dominant strains: those carrying more than 10% of
+        # the sampled population, annotated with their Hamming weight.
+        total = int(counts.sum())
+        vertex_labels = [
+            str(int(hamming_weights[i])) if counts[i] > 0.10 * total else ""
+            for i in range(n_strains)
+        ]
+
+        # Layout: kamada_kawai on the densest graph (max_n) so vertex
+        # positions are stable across subplots.
+        ref_graph = ig.Graph(n=n_strains)
+        ref_graph.add_edges(list(cumulative.keys()))
+        if ref_graph.ecount() > 0:
+            try:
+                layout = ref_graph.layout_kamada_kawai()
+            except Exception:
+                layout = ref_graph.layout_fruchterman_reingold()
+        else:
+            layout = ref_graph.layout_circle()
+        layout_coords = [tuple(c) for c in layout.coords]
+
+        with tp.teed(
+            plt.subplots,
+            nrows=1,
+            ncols=max_n,
+            figsize=(4.5 * max_n, 4.5),
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            if max_n == 1:
+                axes = [axes]
+
+            for ax, (n, edges_dict) in zip(axes, snapshots):
+                edges = list(edges_dict.keys())
+                # 1-hop edges thickest, with progressively thinner widths
+                # for higher-n edges; n>1 edges drawn dashed to distinguish
+                # them from direct mutational neighbors.
+                widths = [3.0 / edges_dict[e] for e in edges]
+                linestyles = ["-" if edges_dict[e] == 1 else "--" for e in edges]
+
+                g_plot = ig.Graph(n=n_strains)
+                if edges:
+                    g_plot.add_edges(edges)
+
+                iplotx.network(
+                    g_plot,
+                    layout=layout_coords,
+                    vertex_facecolor=node_facecolors,
+                    vertex_edgecolor="black",
+                    vertex_size=sizes.tolist(),
+                    vertex_labels=vertex_labels,
+                    vertex_label_color="black",
+                    vertex_label_size=8,
+                    edge_linewidth=widths if widths else 1.0,
+                    edge_linestyle=linestyles if linestyles else "-",
+                    edge_color="gray",
+                    ax=ax,
+                    show=False,
+                )
+                ax.set_title(f"n = {n}")
+                ax.set_aspect("equal")
+
+            # Match make_phylogeny_plot's legend: span the same HW limits
+            # (min/max of present Hamming weights), with up to 4
+            # evenly-spaced entries.
+            present_hw = sorted(int(w) for w in set(hamming_weights.tolist()))
+            if len(present_hw) > 4:
+                idx = np.unique(
+                    np.linspace(0, len(present_hw) - 1, 4).round().astype(int)
+                ).tolist()
+                legend_hw = [present_hw[i] for i in idx]
+            else:
+                legend_hw = present_hw
+
+            handles = [
+                plt.Line2D(
+                    [0],
+                    [0],
+                    marker="o",
+                    color="w",
+                    markerfacecolor=(*palette_colors[w], 0.8),
+                    markeredgecolor="black",
+                    markersize=10,
+                    label=f"HW {w}",
+                )
+                for w in legend_hw
+            ]
+            axes[-1].legend(
+                handles=handles,
+                title="Hamming weight",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+            )
+
+    return (make_strain_graph_plot,)
+
+
+@app.cell
+def def_make_strain_curves_plot(np, pathlib, plt, sns, strain_palette, tp):
+    def make_strain_curves_plot(
+        N_SITES: int,
+        traj_df,
+        strain_df,
+        palette: str = "husl",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Two-panel stacked figure: top = per-strain population-average
+        susceptibility (dashed), bottom = per-strain prevalence (solid).
+        Strains are color-coded by Hamming weight (hue) with lightness
+        disambiguating strains that share a Hamming weight.
+        """
+        n_strains = 1 << N_SITES
+        steps = traj_df["Step"].to_numpy()
+
+        susc_by_site_bit = np.empty((len(traj_df), N_SITES, 2), dtype=float)
+        for site in range(N_SITES):
+            for bit in range(2):
+                susc_by_site_bit[:, site, bit] = traj_df[
+                    f"Susc_S{site}_B{bit}"
+                ].to_numpy()
+
+        # Susceptibility to strain s = product over sites of Susc_S{site}_B{bit}
+        # where `bit` is the allele of strain s at that site.
+        susc_per_strain = np.ones((len(traj_df), n_strains), dtype=float)
+        for s in range(n_strains):
+            for site in range(N_SITES):
+                bit = (s >> site) & 1
+                susc_per_strain[:, s] *= susc_by_site_bit[:, site, bit]
+
+        palette_colors = strain_palette(N_SITES, base_palette=palette)
+
+        with tp.teed(
+            plt.subplots,
+            nrows=2,
+            ncols=1,
+            figsize=(8, 6),
+            sharex=True,
+            gridspec_kw={"hspace": 0.05},
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_susc, ax_prev = axes
+
+            for s in range(n_strains):
+                color = palette_colors[s]
+                label = f"{s:0{N_SITES}b}"
+                ax_susc.plot(
+                    steps,
+                    susc_per_strain[:, s],
+                    color=color,
+                    linestyle="--",
+                    linewidth=1.5,
+                    label=label,
+                )
+
+                strain_s = strain_df[strain_df["strain"] == s]
+                strain_s = strain_s.sort_values("Step")
+                ax_prev.plot(
+                    strain_s["Step"].to_numpy(),
+                    strain_s["count"].to_numpy(),
+                    color=color,
+                    linestyle="-",
+                    linewidth=1.5,
+                    label=label,
+                )
+
+            ax_susc.set_ylabel("Population Susceptibility")
+            ax_susc.set_ylim(0.0, 1.0)
+            ax_prev.set_ylabel("Case Burden")
+            ax_prev.set_xlabel("Time")
+            ax_prev.set_ylim(bottom=0.0)
+
+            ax_susc.legend(
+                title="strain",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1 if n_strains <= 8 else 2,
+                fontsize=8,
+            )
+            sns.despine(ax=ax_susc)
+            sns.despine(ax=ax_prev)
+
+    return (make_strain_curves_plot,)
+
+
+@app.cell
+def def_make_allele_curves_plot(allele_palette, np, pathlib, plt, sns, tp):
+    def make_allele_curves_plot(
+        N_SITES: int,
+        traj_df,
+        strain_df,
+        palette: str = "husl",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Two-panel stacked figure aggregated by individual allele:
+        top = per-(site, allele) population-average susceptibility
+        (dashed); bottom = per-(site, allele) prevalence (solid). Each
+        site gets its own ggplot-style HCL hue; the two alleles within
+        a site are split by lightness (allele 0 darker, allele 1 lighter).
+        """
+        n_strains = 1 << N_SITES
+        steps = traj_df["Step"].to_numpy()
+
+        # Per-(site, allele) susceptibility comes straight from the
+        # `Susc_S{site}_B{bit}` columns logged by simulate().
+        susc_per_allele = np.empty((len(traj_df), N_SITES, 2), dtype=float)
+        for site in range(N_SITES):
+            for bit in range(2):
+                susc_per_allele[:, site, bit] = traj_df[
+                    f"Susc_S{site}_B{bit}"
+                ].to_numpy()
+
+        # Per-(site, allele) prevalence is the sum of strain prevalences
+        # over strains carrying that allele at that site.
+        unique_steps = sorted(strain_df["Step"].unique())
+        step_to_idx = {t: i for i, t in enumerate(unique_steps)}
+        prev_per_allele = np.zeros((len(unique_steps), N_SITES, 2), dtype=float)
+        for s in range(n_strains):
+            sub = strain_df[strain_df["strain"] == s]
+            for _, row in sub.iterrows():
+                idx = step_to_idx[row["Step"]]
+                count = float(row["count"])
+                for site in range(N_SITES):
+                    bit = (s >> site) & 1
+                    prev_per_allele[idx, site, bit] += count
+
+        site_allele_to_color = allele_palette(N_SITES, base_palette=palette)
+
+        with tp.teed(
+            plt.subplots,
+            nrows=2,
+            ncols=1,
+            figsize=(8, 6),
+            sharex=True,
+            gridspec_kw={"hspace": 0.05},
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_susc, ax_prev = axes
+
+            for site in range(N_SITES):
+                for allele in (0, 1):
+                    color = site_allele_to_color[(site, allele)]
+                    label = f"S{site}A{allele}"
+                    ax_susc.plot(
+                        steps,
+                        susc_per_allele[:, site, allele],
+                        color=color,
+                        linestyle="--",
+                        linewidth=1.5,
+                        label=label,
+                    )
+                    ax_prev.plot(
+                        unique_steps,
+                        prev_per_allele[:, site, allele],
+                        color=color,
+                        linestyle="-",
+                        linewidth=1.5,
+                        label=label,
+                    )
+
+            ax_susc.set_ylabel("Population Susceptibility")
+            ax_susc.set_ylim(0.0, 1.0)
+            ax_prev.set_ylabel("Case Burden")
+            ax_prev.set_xlabel("Time")
+            ax_prev.set_ylim(bottom=0.0)
+
+            ax_susc.legend(
+                title="site / allele",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1,
+                fontsize=8,
+            )
+            sns.despine(ax=ax_susc)
+            sns.despine(ax=ax_prev)
+
+    return
+
+
+@app.cell
+def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
+    def make_r_curves_plot(
+        N_SITES: int,
+        strain_df,
+        RECOVERY_RATE: float,
+        smoothing_windows=(1, 5, 25, 125),
+        palette: str = "husl",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Multi-row figure of per-strain reproduction number. The
+        first row plots the *expected* R per strain on its own; each
+        subsequent row plots the *actual* R per strain at a
+        different rolling-mean window (unsmoothed first). Both per-
+        step rates are scaled by the discrete-time R0 multiplier
+        `(1 - RECOVERY_RATE) / RECOVERY_RATE` so the plotted values
+        are the expected number of total transmissions caused by a
+        single primary infection (an `R0`-like quantity) rather than
+        the per-step rate. The factor is `(1 - p) / p` rather than
+        `1 / p` because `update_recoveries` runs after
+        `transmit_infection` within the same step, so a just-infected
+        primary faces an immediate recovery check before it can
+        transmit at the next step.
+
+        * actual R(t, s) = (new_infections(s, t) /
+          n_with_strain(s, t)) * (1 - RECOVERY_RATE) / RECOVERY_RATE.
+          Rolling-mean smoothed with the row's window.
+        * expected R(t, s) = expected_R_per_step(s, t) *
+          (1 - RECOVERY_RATE) / RECOVERY_RATE, where the per-step
+          quantity is the population-average probability that strain
+          s infects a randomly-sampled individual on a single contact
+          in one step (logged per step as `strain_df["expected_R"]`,
+          with currently-infected hosts contributing 0 since they
+          cannot be re-infected). Plotted unsmoothed since it is
+          already a smooth function of population state.
+
+        Strains are color-coded by Hamming weight (hue) with
+        lightness disambiguating strains of the same weight. The
+        epidemic threshold R = 1 is drawn as a dotted reference line.
+        """
+        n_strains = 1 << N_SITES
+
+        unique_steps = np.array(sorted(strain_df["Step"].unique()), dtype=float)
+        T = len(unique_steps)
+        step_to_idx = {t: i for i, t in enumerate(unique_steps.tolist())}
+
+        prev_per_strain = np.zeros((T, n_strains), dtype=float)
+        new_inf_per_strain = np.zeros((T, n_strains), dtype=float)
+        expected_R_per_strain = np.zeros((T, n_strains), dtype=float)
+
+        for _, row in strain_df.iterrows():
+            i = step_to_idx[row["Step"]]
+            s = int(row["strain"])
+            prev_per_strain[i, s] = float(row["count"])
+            new_inf_per_strain[i, s] = float(row.get("new_infections", 0.0))
+            expected_R_per_strain[i, s] = float(row.get("expected_R", 0.0))
+
+        # Convert per-step rates to per-primary R0-like totals. A
+        # primary newly infected in step t's transmit_infection faces
+        # update_recoveries in the same step, so it participates as a
+        # source in step t+1 only with prob (1 - p), in step t+2 with
+        # prob (1 - p)^2, etc. The expected number of future
+        # transmit_infection participations is therefore
+        # sum_{k=1}^inf (1-p)^k = (1 - p) / p, NOT 1 / p (off-by-one
+        # if you forget that update_recoveries runs after
+        # transmit_infection within the same step).
+        r0_multiplier = (1.0 - RECOVERY_RATE) / RECOVERY_RATE
+        expected_R_per_strain = expected_R_per_strain * r0_multiplier
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            r_actual_per_strain = np.where(
+                prev_per_strain > 0,
+                new_inf_per_strain / prev_per_strain,
+                np.nan,
+            )
+        r_actual_per_strain = r_actual_per_strain * r0_multiplier
+
+        palette_colors = strain_palette(N_SITES, base_palette=palette)
+
+        windows = list(smoothing_windows)
+        if not windows or windows[0] != 1:
+            windows = [1] + windows
+
+        n_rows = 1 + len(windows)
+
+        with tp.teed(
+            plt.subplots,
+            nrows=n_rows,
+            ncols=1,
+            figsize=(8, 2.0 * n_rows + 1.0),
+            sharex=True,
+            gridspec_kw={"hspace": 0.08},
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_expected = axes[0]
+            actual_axes = axes[1:]
+
+            for s in range(n_strains):
+                color = palette_colors[s]
+                label = f"{s:0{N_SITES}b}"
+                ax_expected.plot(
+                    unique_steps,
+                    expected_R_per_strain[:, s],
+                    color=color,
+                    linestyle="--",
+                    linewidth=1.5,
+                    label=label,
+                )
+            ax_expected.axhline(1.0, color="gray", linestyle=":", linewidth=0.8)
+            ax_expected.set_ylabel("expected R")
+            ax_expected.set_ylim(bottom=0.0)
+            sns.despine(ax=ax_expected)
+
+            ax_expected.legend(
+                title="strain",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1 if n_strains <= 8 else 2,
+                fontsize=8,
+            )
+
+            for ax, w in zip(actual_axes, windows):
+                for s in range(n_strains):
+                    color = palette_colors[s]
+                    actual = pd.Series(r_actual_per_strain[:, s])
+                    if w > 1:
+                        actual = actual.rolling(
+                            window=w,
+                            min_periods=max(1, w // 4),
+                            center=True,
+                        ).mean()
+                    ax.plot(
+                        unique_steps,
+                        actual.to_numpy(),
+                        color=color,
+                        linestyle="-",
+                        linewidth=1.2,
+                    )
+                ax.axhline(1.0, color="gray", linestyle=":", linewidth=0.8)
+                ax.set_ylabel(f"actual R\nrolling window = {w}")
+                sns.despine(ax=ax)
+
+            actual_axes[-1].set_xlabel("Time")
+
+    return (make_r_curves_plot,)
+
+
+@app.cell
+def def_make_density_heatmap_plot(np, pathlib, plt, sns, tp):
+    import matplotlib.colors as mcolors
+
+    def make_density_heatmap_plot(
+        N_SITES: int,
+        strain_df,
+        cmap: str = "rocket_r",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Heatmap of population density binned by Hamming distance to
+        the end-state most populous strain. y-axis is the number of
+        bits in common with that reference strain (top = identical
+        with the end-state strain, bottom = its complement); x-axis is
+        time. Each column is normalized to sum to 1, so cells encode
+        the proportion of *circulating* strains (not the host
+        population fraction) sharing the given number of bits with the
+        reference at the given step. The colormap is truncated and
+        true-zero cells are masked white so that barely-positive bins
+        are clearly distinguishable from empty bins.
+        """
+        n_strains = 1 << N_SITES
+
+        unique_steps = np.array(sorted(strain_df["Step"].unique()), dtype=np.int64)
+        T = len(unique_steps)
+        final_step = int(unique_steps.max())
+
+        final = strain_df[strain_df["Step"] == final_step]
+        end_strain = int(final.loc[final["count"].idxmax(), "strain"])
+
+        bits_in_common = N_SITES - np.array(
+            [bin(int(s) ^ end_strain).count("1") for s in range(n_strains)],
+            dtype=np.int64,
+        )
+
+        strains_arr = strain_df["strain"].to_numpy().astype(np.int64)
+        steps_arr = strain_df["Step"].to_numpy().astype(np.int64)
+        counts_arr = strain_df["count"].to_numpy(dtype=float)
+        bic_arr = bits_in_common[strains_arr]
+        step_idx_arr = np.searchsorted(unique_steps, steps_arr)
+
+        density = np.zeros((N_SITES + 1, T), dtype=float)
+        np.add.at(density, (bic_arr, step_idx_arr), counts_arr)
+
+        # Normalize each column so values represent the proportion of
+        # *circulating* strains rather than the host-population
+        # fraction. Steps with no infections leave the column at zero.
+        col_totals = density.sum(axis=0, keepdims=True)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            density = np.where(col_totals > 0, density / col_totals, 0.0)
+
+        base_cmap = plt.get_cmap(cmap)
+        trunc_cmap = mcolors.LinearSegmentedColormap.from_list(
+            f"{cmap}_trunc",
+            base_cmap(np.linspace(0.2, 1.0, 256)),
+        )
+        trunc_cmap.set_bad("white")
+        masked_density = np.ma.masked_equal(density, 0.0)
+
+        with tp.teed(
+            plt.subplots,
+            figsize=(8, 3),
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, ax):
+            # origin="lower" places density[0, :] (bits_in_common = 0,
+            # complement of end-state strain) at the bottom and
+            # density[N_SITES, :] (identical with end-state) at the top.
+            im = ax.imshow(
+                masked_density,
+                origin="lower",
+                aspect="auto",
+                cmap=trunc_cmap,
+                vmin=0.0,  # Set the bottom of the colormap scale
+                vmax=0.33,  # Saturate anything above 0.33
+                extent=[
+                    float(unique_steps.min()) - 0.5,
+                    float(unique_steps.max()) + 0.5,
+                    -0.5,
+                    N_SITES + 0.5,
+                ],
+                interpolation="nearest",
+            )
+            ax.set_yticks(np.arange(N_SITES + 1))
+            ax.set_xlabel("Time")
+            ax.set_ylabel(
+                "bits in common with\nend-state strain " f"{end_strain:0{N_SITES}b}"
+            )
+            cbar = fig.colorbar(im, ax=ax, pad=0.02)
+            cbar.set_label("Fraction of circulating strains")
+            sns.despine(ax=ax)
+
+    return (make_density_heatmap_plot,)
+
+
+@app.cell
+def _(np, pathlib, pd, sns, tp, warnings):
+    def make_density_ridge_plot(
+        N_SITES: int,
+        strain_df: pd.DataFrame,
+        cmap: str = "rocket_r",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Ridge plot of population density binned by Hamming distance to
+        the end-state most populous strain over time.
+
+        Uses manual column-by-column normalization mapped to an explicit
+        stepped histplot to guarantee exact relative densities and avoid KDE/binning warnings.
+        """
+        n_strains = 1 << N_SITES
+
+        unique_steps = np.array(sorted(strain_df["Step"].unique()), dtype=np.int64)
+        T = len(unique_steps)
+        final_step = int(unique_steps.max())
+
+        final = strain_df[strain_df["Step"] == final_step]
+        end_strain = int(final.loc[final["count"].idxmax(), "strain"])
+
+        bits_in_common = N_SITES - np.array(
+            [bin(int(s) ^ end_strain).count("1") for s in range(n_strains)],
+            dtype=np.int64,
+        )
+
+        strains_arr = strain_df["strain"].to_numpy().astype(np.int64)
+        steps_arr = strain_df["Step"].to_numpy().astype(np.int64)
+        counts_arr = strain_df["count"].to_numpy(dtype=float)
+        bic_arr = bits_in_common[strains_arr]
+        step_idx_arr = np.searchsorted(unique_steps, steps_arr)
+
+        # 1. Manually calculate the exact density matrix (from original heatmap logic)
+        density = np.zeros((N_SITES + 1, T), dtype=float)
+        np.add.at(density, (bic_arr, step_idx_arr), counts_arr)
+
+        # 2. Normalize each column so values represent the proportion of *circulating* strains
+        col_totals = density.sum(axis=0, keepdims=True)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            density = np.where(col_totals > 0, density / col_totals, 0.0)
+
+        # 3. Convert the exact density matrix into a tidy dataframe for Seaborn
+        rows = []
+        for bic in range(N_SITES + 1):
+            for t_idx, step in enumerate(unique_steps):
+                rows.append(
+                    {
+                        "bits_in_common": bic,
+                        "Step": step,
+                        "norm_density": density[bic, t_idx],
+                    }
+                )
+        plot_df = pd.DataFrame(rows)
+
+        # 4. Construct explicit bin edges and convert to LIST to prevent Seaborn array evaluation bug
+        if len(unique_steps) > 1:
+            half_step = (unique_steps[1] - unique_steps[0]) / 2.0
+            np.append(unique_steps - half_step, unique_steps[-1] + half_step).tolist()
+        else:
+            strain_df["Step"].max() + 1  # Fallback
+
+        # Set up the order so the end-state strain (N_SITES bits in common) is at the top
+        # Convert to list to prevent any other numpy array truth value evaluation bugs
+        row_order = list(range(N_SITES, -1, -1))
+
+        # Initialize the palette
+        pal = sns.color_palette(cmap, n_colors=N_SITES + 1)
+
+        with warnings.catch_warnings():
+            # Suppress the tight_layout warning caused by our intentional negative hspace squishing
+            warnings.filterwarnings(
+                "ignore",
+                message="This figure includes Axes that are not compatible with tight_layout",
+                category=UserWarning,
+            )
+
+            # Use teeplot directly on displot; it yields the FacetGrid object
+            with tp.teed(
+                sns.displot,
+                data=plot_df,
+                x="Step",
+                weights="norm_density",  # Use our manually calculated exact proportions
+                row="bits_in_common",
+                hue="bits_in_common",
+                kind="hist",
+                # bins=bins,              # Explicit list bins silence the warning
+                element="step",  # Continuous step outline
+                row_order=row_order,
+                hue_order=row_order,
+                discrete=True,
+                aspect=15,
+                height=0.2,
+                palette=pal,
+                clip_on=False,
+                fill=True,
+                alpha=0.8,
+                linewidth=1.5,
+                # facet_kws={"gridspec_kws": {"hspace": -0.25}},
+                teeplot_outattrs=teeplot_outattrs,
+                teeplot_show=True,
+                teeplot_subdir=pathlib.Path(__file__).stem,
+            ) as g:
+
+                # # Draw a white outline over the stepped ridges
+                # g.map_dataframe(
+                #     sns.histplot,
+                #     x="Step",
+                #     weights="norm_density",
+                #     bins=bins,
+                #     element="step",
+                #     clip_on=False,
+                #     fill=False,
+                #     color="w",
+                #     lw=2
+                # )
+
+                # Add a horizontal reference line at the base of each ridge
+                # g.refline(y=0, linewidth=2, linestyle="-", color=None, clip_on=False)
+
+                # Safely apply labels by iterating over the flat axes directly
+                for ax, label_val, color in zip(g.axes.flat, row_order, pal):
+                    ax.text(
+                        -0.02,
+                        0.2,
+                        f"{label_val} bits",
+                        fontweight="bold",
+                        color=color,
+                        ha="right",
+                        va="center",
+                        transform=ax.transAxes,
+                    )
+
+                # Fallback to ensure the rows are perfectly squished
+                # g.figure.subplots_adjust(hspace=-0.25)
+
+                # Clean up standard axes details and definitively remove subplot titles
+                g.set_titles("")
+                g.set(yticks=[], ylabel="", ylim=(0, None))
+                g.despine(bottom=True, left=True)
+
+                # Enforce standard X-axis formatting
+                g.set_xlabels("Time")
+
+    return (make_density_ridge_plot,)
+
+
+@app.cell
+def run_phylogeny_sweep(
+    ENGINE,
+    N_REPLICATES,
+    N_STEPS,
+    POP_SIZE,
+    POW,
+    SKIP_PLOTTING,
+    gc,
+    make_density_heatmap_plot,
+    make_density_ridge_plot,
+    make_phylogeny_plot,
+    make_r_curves_plot,
+    make_strain_curves_plot,
+    make_strain_graph_plot,
+    pathlib,
+    pd,
+    reconstruct_phylogeny,
+    simulate,
+    uuid,
+):
+    PHYLO_MUTATION_RATE = 1e-5
+
+    # Sweep conditions: (N_SITES, pow). Low-N_SITES rows reuse the CLI
+    # `pow` value; the 8- and 16-site rows tune `pow` down to keep the
+    # R0-like quantity in a comparable range when more sites multiply
+    # the per-strain susceptibility product.
+    PHYLO_CONDITIONS = (
+        (2, POW),
+        (3, POW),
+        (4, POW),
+        # (20, 2.5),
+        # (20, 1),
+        # (20, 1.5),
+        # (12, 2.5),
+        # (16, 0.25),
+    )
+
+    nbname = pathlib.Path(__file__).stem
+    out_dir = pathlib.Path("outdata") / nbname
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    def _save_replicate(kind: str, uid: str, df) -> None:
+        rep_dir = out_dir / kind / uid
+        rep_dir.mkdir(parents=True, exist_ok=True)
+        rep_path = rep_dir / f"a={kind}+what={nbname}+ext=.pqt"
+        df.to_parquet(rep_path, index=False)
+        print(f"  wrote {kind} parquet ({len(df)} rows): {rep_path}")
+
+    traj_chunks = []
+    hw_chunks = []
+    strain_chunks = []
+    records_chunks = []
+    phylo_chunks = []
+
+    for _seed in range(1, N_REPLICATES + 1):
+        for PHYLO_N_SITES, POW_ in PHYLO_CONDITIONS:
+            1 << PHYLO_N_SITES
+            do_per_strain_plots = True
+            replicate_uid = uuid.uuid4().hex
+            print(
+                f"=== seed={_seed} N_SITES={PHYLO_N_SITES} "
+                f"pow={POW_} uid={replicate_uid} ===",
+            )
+            CONTACT_RATE_ = 0.35
+            RECOVERY_RATE_ = 0.1
+            _phylo_df, _hw_df, _strain_df, _records_df = simulate(
+                MUTATION_RATE=PHYLO_MUTATION_RATE,
+                N_SITES=PHYLO_N_SITES,
+                N_STEPS=1_200,
+                POP_SIZE=10_000,
+                CONTACT_RATE=CONTACT_RATE_,
+                RECOVERY_RATE=RECOVERY_RATE_,
+                WANING_RATE=0.03,
+                IMMUNE_STRENGTH=0.7,
+                SEED_COUNT=5,
+                IMMUNITY_FLOOR=0.05,
+                IMMUNITY_CEILING=1.0,
+                seed=_seed,
+                track_phylogeny=True,
+                N_SAMPLE=200,
+                pow=POW_,
+            )
+            print(f"  snapshot rows: {len(_records_df)}")
+
+            _params = {
+                "replicate_uid": replicate_uid,
+                "seed": _seed,
+                "n_sites": PHYLO_N_SITES,
+                "pop_size": POP_SIZE,
+                "n_steps": N_STEPS,
+                "engine": ENGINE,
+                "pow": POW_,
+            }
+            _traj_stamped = _phylo_df.assign(**_params)
+            _hw_stamped = _hw_df.assign(**_params)
+            _strain_stamped = _strain_df.assign(**_params)
+            traj_chunks.append(_traj_stamped)
+            hw_chunks.append(_hw_stamped)
+            strain_chunks.append(_strain_stamped)
+            _save_replicate("traj", replicate_uid, _traj_stamped)
+            _save_replicate("hw", replicate_uid, _hw_stamped)
+            _save_replicate("strain", replicate_uid, _strain_stamped)
+
+            _records_stamped = _records_df.assign(**_params)
+            records_chunks.append(_records_stamped)
+            _save_replicate("records", replicate_uid, _records_stamped)
+
+            if SKIP_PLOTTING:
+                print("  (SKIP_PLOTTING=True — skipping strain curves)")
+            else:
+                for palette in "husl", "hls", "Set2":
+                    if PHYLO_N_SITES < 8:
+                        make_strain_curves_plot(
+                            PHYLO_N_SITES,
+                            _phylo_df,
+                            _strain_df,
+                            palette=palette,
+                            teeplot_outattrs={
+                                "a": "strain-curves",
+                                "n_sites": PHYLO_N_SITES,
+                                "n_steps": int(_phylo_df["Step"].max()) + 1,
+                                "replicate": _seed,
+                                "palette": palette,
+                                "pow": POW_,
+                            },
+                        )
+                    # make_allele_curves_plot(
+                    #     PHYLO_N_SITES,
+                    #     _phylo_df,
+                    #     _strain_df,
+                    #     palette=palette,
+                    #     teeplot_outattrs={
+                    #         "a": "allele-curves",
+                    #         "n_sites": PHYLO_N_SITES,
+                    #         "n_steps": int(_phylo_df["Step"].max()) + 1,
+                    #         "replicate": _seed,
+                    #         "palette": palette,
+                    #         "pow": POW_,
+                    #     },
+                    # )
+                    if PHYLO_N_SITES < 8:
+                        make_r_curves_plot(
+                            PHYLO_N_SITES,
+                            _strain_df,
+                            RECOVERY_RATE=RECOVERY_RATE_,
+                            palette=palette,
+                            teeplot_outattrs={
+                                "a": "r-curves",
+                                "n_sites": PHYLO_N_SITES,
+                                "n_steps": int(_phylo_df["Step"].max()) + 1,
+                                "replicate": _seed,
+                                "palette": palette,
+                                "pow": POW_,
+                            },
+                        )
+                for cmap in "rocket", "viridis", "magma":
+                    make_density_ridge_plot(
+                        PHYLO_N_SITES,
+                        _strain_df,
+                        cmap=cmap,
+                        teeplot_outattrs={
+                            "a": "density-ridgeplot",
+                            "n_sites": PHYLO_N_SITES,
+                            "n_steps": int(_phylo_df["Step"].max()) + 1,
+                            "replicate": _seed,
+                            "cmap": cmap,
+                            "pow": POW_,
+                        },
+                    )
+                    make_density_heatmap_plot(
+                        PHYLO_N_SITES,
+                        _strain_df,
+                        cmap=cmap,
+                        teeplot_outattrs={
+                            "a": "density-heatmap",
+                            "n_sites": PHYLO_N_SITES,
+                            "n_steps": int(_phylo_df["Step"].max()) + 1,
+                            "replicate": _seed,
+                            "cmap": cmap,
+                            "pow": POW_,
+                        },
+                    )
+
+            if len(_records_df) == 0:
+                print("  (no infected hosts --- skipping plot)")
+                del _phylo_df, _hw_df, _strain_df, _records_df
+                gc.collect()
+                continue
+
+            print(f"  extant rows: {int(_records_df['extant'].sum())}")
+            for palette in "rocket_r", "tab20", "tab10":
+                if SKIP_PLOTTING:
+                    print("  (SKIP_PLOTTING=True — skipping strain graph)")
+                elif not do_per_strain_plots:
+                    print(
+                        "  (n_strains too large — skipping strain graph)",
+                    )
+                else:
+                    make_strain_graph_plot(
+                        PHYLO_N_SITES,
+                        _records_df,
+                        max_n=4,
+                        palette=palette,
+                        teeplot_outattrs={
+                            "a": "strain-graph",
+                            "n_sites": PHYLO_N_SITES,
+                            "n_steps": int(_phylo_df["Step"].max()) + 1,
+                            "replicate": _seed,
+                            "palette": palette,
+                            "pow": POW_,
+                        },
+                    )
+            _phylogeny_df = reconstruct_phylogeny(_records_df)
+            del _records_df
+            gc.collect()
+            print(f"  reconstructed: {len(_phylogeny_df)} nodes")
+            print(f"  extant tips: {int(_phylogeny_df['extant'].sum())}")
+
+            _phylo_stamped = _phylogeny_df.assign(**_params)
+            phylo_chunks.append(_phylo_stamped)
+            _save_replicate("phylo", replicate_uid, _phylo_stamped)
+
+            for palette in "rocket_r", "tab20", "tab10":
+                if SKIP_PLOTTING:
+                    print("  (SKIP_PLOTTING=True — skipping plot)")
+                else:
+                    make_phylogeny_plot(
+                        PHYLO_N_SITES,
+                        _phylo_df,
+                        _hw_df,
+                        _phylogeny_df,
+                        seed=_seed,
+                        palette=palette,
+                        teeplot_outattrs={
+                            "n_sites": PHYLO_N_SITES,
+                            "n_steps": int(_phylo_df["Step"].max()) + 1,
+                            "replicate": _seed,
+                            "palette": palette,
+                            "method": "hstrat-surface",
+                            "pow": POW_,
+                        },
+                    )
+            del _phylo_df, _hw_df, _strain_df, _phylogeny_df
+            gc.collect()
+
+    traj_df_all = (
+        pd.concat(traj_chunks, ignore_index=True) if traj_chunks else pd.DataFrame()
+    )
+    hw_df_all = pd.concat(hw_chunks, ignore_index=True) if hw_chunks else pd.DataFrame()
+    strain_df_all = (
+        pd.concat(strain_chunks, ignore_index=True) if strain_chunks else pd.DataFrame()
+    )
+    records_df_all = (
+        pd.concat(records_chunks, ignore_index=True)
+        if records_chunks
+        else pd.DataFrame()
+    )
+    phylo_df_all = (
+        pd.concat(phylo_chunks, ignore_index=True) if phylo_chunks else pd.DataFrame()
+    )
+
+    traj_path = out_dir / f"a=traj+what={nbname}+ext=.pqt"
+    hw_path = out_dir / f"a=hw+what={nbname}+ext=.pqt"
+    strain_path = out_dir / f"a=strain+what={nbname}+ext=.pqt"
+    records_path = out_dir / f"a=records+what={nbname}+ext=.pqt"
+    phylo_path = out_dir / f"a=phylo+what={nbname}+ext=.pqt"
+    traj_df_all.to_parquet(traj_path, index=False)
+    hw_df_all.to_parquet(hw_path, index=False)
+    strain_df_all.to_parquet(strain_path, index=False)
+    records_df_all.to_parquet(records_path, index=False)
+    phylo_df_all.to_parquet(phylo_path, index=False)
+    print(f"wrote trajectory parquet ({len(traj_df_all)} rows): {traj_path}")
+    print(f"wrote hw parquet ({len(hw_df_all)} rows): {hw_path}")
+    print(f"wrote strain parquet ({len(strain_df_all)} rows): {strain_path}")
+    print(f"wrote records parquet ({len(records_df_all)} rows): {records_path}")
+    print(f"wrote phylogeny parquet ({len(phylo_df_all)} rows): {phylo_path}")
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Adds make_density_heatmap_plot to the r-per-strain notebook: y-axis is
the number of bits in common with the end-state most populous strain
(top = identical, bottom = complement), x-axis is time, and cell
intensity is the aggregated population fraction over strains sharing
that many bits with the reference at the given step.

https://claude.ai/code/session_01Let8HaQVDJUZotjPvMH2uz