### PR TITLE
Add founder notebook for single-replicate allele-based ABM simulations

### DIFF
--- a/bindle/2026-05-20-founder.py
+++ b/bindle/2026-05-20-founder.py
@@ -1,0 +1,2093 @@
+import marimo
+
+__generated_with = "0.23.2"
+app = marimo.App(width="full")
+
+
+@app.cell
+def import_std():
+    import gc
+    import pathlib
+    import random
+    from typing import Dict, List, Sequence, Tuple, Union
+    import uuid
+
+    return Dict, List, Sequence, Tuple, Union, gc, pathlib, random, uuid
+
+
+@app.cell
+def import_pkg():
+    try:
+        import cupy as cp
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "cupy import failed; falling back to numpy "
+            "(GPU engine unavailable)",
+            stacklevel=2,
+        )
+        import numpy as cp
+
+    # workaround: iplotx 1.7.x uses importlib.metadata without importing it
+    import importlib.metadata  # noqa: F401
+
+    import downstream.dstream as dstream
+    import hstrat
+    import igraph as ig
+    import iplotx
+    import marimo as mo
+    import matplotlib.pyplot as plt
+    from matplotlib.ticker import FuncFormatter, MaxNLocator
+    import numpy as np
+    import pandas as pd
+    from phyloframe import legacy as pfl
+    import polars as pl
+    import seaborn as sns
+    from teeplot import teeplot as tp
+    from tqdm.auto import tqdm
+    from watermark import watermark
+
+    from pylib import allele_palette, draw_scatter_tree, strain_palette
+
+    return (
+        FuncFormatter,
+        MaxNLocator,
+        allele_palette,
+        cp,
+        draw_scatter_tree,
+        dstream,
+        hstrat,
+        ig,
+        iplotx,
+        mo,
+        np,
+        pd,
+        pfl,
+        pl,
+        plt,
+        sns,
+        strain_palette,
+        tp,
+        tqdm,
+        watermark,
+    )
+
+
+@app.cell(hide_code=True)
+def do_watermark(mo, watermark):
+    mo.md(
+        f"""
+    ```Text
+    {watermark(
+        current_date=True,
+        iso8601=True,
+        machine=True,
+        updated=True,
+        python=True,
+        iversions=True,
+        globals_=globals(),
+    )}
+    ```
+    """
+    )
+    return
+
+
+@app.cell
+def configure_args(mo):
+    # Command-line args for a single founder replicate. Set them after a
+    # `--` separator, e.g.
+    #   marimo export ipynb 2026-05-20-founder.py -o out.ipynb -- \
+    #       --seed 3 --n-sites 8 --pop-size 200000 --n-steps 600
+    # or `marimo edit 2026-05-20-founder.py -- --seed 3 ...`. Every arg
+    # has a default, so the notebook also runs with no args at all.
+    _args = mo.cli_args()
+    SEED = int(_args.get("seed") or 1)
+    N_SITES = int(_args.get("n-sites") or 4)
+    POP_SIZE = int(_args.get("pop-size") or 100_000)
+    N_STEPS = int(_args.get("n-steps") or 1_200)
+    POW = float(_args.get("pow") or 1.0)
+    ENGINE = str(_args.get("engine") or "numpy").lower()
+    if ENGINE not in ("numpy", "cupy"):
+        raise ValueError(
+            f"engine must be 'numpy' or 'cupy', got {ENGINE!r}",
+        )
+    SKIP_PLOTTING = bool(_args.get("skip-plotting") or False)
+    print(
+        f"args: SEED={SEED} N_SITES={N_SITES} POP_SIZE={POP_SIZE} "
+        f"N_STEPS={N_STEPS} POW={POW} ENGINE={ENGINE} "
+        f"SKIP_PLOTTING={SKIP_PLOTTING}",
+    )
+    return ENGINE, N_SITES, N_STEPS, POP_SIZE, POW, SEED, SKIP_PLOTTING
+
+
+@app.cell
+def configure_backend(ENGINE, cp, np):
+    use_cupy = (
+        ENGINE == "cupy"
+    )  # use cupy backend (GPU), otherwise numpy (CPU)
+    xp = [np, cp][use_cupy]
+    return (xp,)
+
+
+@app.cell(hide_code=True)
+def delimit_simulation(mo):
+    mo.md(
+        """
+    ## Simulation Implementation
+
+    This is a **founder** notebook: it runs a *single replicate* of the
+    allele-based agent-based model (ABM) for one random seed and one
+    `N_SITES` condition, both chosen on the command line. It is a
+    single-run, command-line companion to the multi-condition sweep in
+    `2026-05-06-allele-abm-r-per-strain.py`, and reuses that notebook's
+    `simulate()` implementation, reconstruction, and figures unchanged.
+
+    Every run setting is a CLI argument with a default, so the notebook
+    runs unconfigured but can be pointed at a specific replicate (pass
+    args after a `--` separator, see the args cell above):
+
+    * `--seed` --- replicate random seed (default `1`).
+    * `--n-sites` --- number of allele sites / genome bits, which sets
+      the strain count `2 ** N_SITES` (default `4`).
+    * `--pop-size` --- host population size (default `100_000`).
+    * `--n-steps` --- number of simulation updates / steps to run
+      (default `1_200`).
+    * `--engine` --- compute backend, `numpy` (CPU) or `cupy` (GPU)
+      (default `numpy`).
+    * `--pow` --- susceptibility-product exponent (default `1.0`).
+    * `--skip-plotting` --- skip figure rendering (default `False`).
+
+    Each genome bit is an allele; a circulating strain's **Hamming
+    weight** is its number of `1` bits, i.e. the number of mutations
+    separating it from the founder (wildtype, all-zero) strain seeded at
+    step 0. The per-step Hamming-weight distribution of circulating
+    strains is logged **as a raw case count** --- the number of
+    currently-infected hosts at each Hamming weight --- in the
+    `n_cases` column of the `hw` dataframe, alongside the inherited
+    population-fraction `count` column. Every output dataframe is also
+    stamped with the simulation parameters as constant-valued columns
+    and a `replicate_uid` generated with the standard-library `uuid`
+    module, so rows from a run are self-describing and uniquely
+    identifiable.
+
+    When the strain count `2 ** N_SITES` exceeds 16, the per-strain
+    figures (strain curves, R-curves, strain summary, strain graph) are
+    skipped --- one line/node per strain is unreadable, and the dense
+    `(POP_SIZE, n_strains, N_SITES)` susceptibility tensor used for
+    expected-R is gated off above a memory cap. The Hamming-weight
+    stackplot and Hamming-distance density heatmap aggregate only
+    `N_SITES + 1` bins, so they continue to render at large `N_SITES`.
+
+    The inherited "r-curves" figure is a multi-row stack with the
+    *expected* per-strain reproduction number on the very top row by
+    itself, and the *actual* per-strain reproduction number on
+    subsequent rows at increasing rolling-mean windows (unsmoothed
+    first). Both per-step rates are scaled by the discrete-time R0
+    multiplier
+    `(1 - RECOVERY_RATE) / RECOVERY_RATE` so the plotted values are
+    the expected total infections caused by a single primary (an
+    `R0`-like quantity) rather than the per-step rate, and `R = 1`
+    is drawn as the epidemic-threshold reference line. The factor
+    is `(1 - p) / p` rather than `1 / p` because
+    `update_recoveries` runs after `transmit_infection` within the
+    same step, so a primary newly infected in step `t` faces an
+    immediate recovery check before participating as a source at
+    step `t+1`; the expected number of future transmit-as-source
+    steps is `sum_{k=1}^inf (1 - p)^k = (1 - p) / p` (off-by-one if
+    you forget the within-step recovery).
+
+    * `R_actual(t, s) = new_infections(s, t) /
+      n_with_strain(s, t) * (1 - RECOVERY_RATE) / RECOVERY_RATE` --
+      new strain-`s` infections caused per current strain-`s`
+      infected per step, multiplied by the R0 multiplier, computed
+      from instrumentation logged inside `simulate()`.
+      `new_infections` is captured pre-mutation in
+      `update_simulation()` so the strain label reflects the strain
+      that actually transmitted, not its post-mutation descendant.
+
+    * `R_expected(t, s) = R_expected_per_step(s, t) *
+      (1 - RECOVERY_RATE) / RECOVERY_RATE`, where
+      `R_expected_per_step(s, t)` is the average over the population
+      of the probability that strain `s` infects a randomly-sampled
+      individual on a single contact in one step. Currently-infected
+      hosts contribute zero since they cannot be re-infected --- the
+      `(host_statuses == 0)` mask zeros out their per-host
+      susceptibilities before averaging over the full `POP_SIZE`, so
+      the mean already accounts for the susceptible-only fraction.
+      The per-step quantity is logged as `strain_df["expected_R"]`
+      alongside `count` and `new_infections`; multiplying by the
+      R0 multiplier gives the analog of `R0`.
+
+    Phylogeny estimation still uses *hereditary stratigraphic surface*
+    annotations (see https://hstrat.rtfd.io). Each infected host carries
+    a `dstream_S=64`-site, 1-bit "hybrid" surface; the donor surface
+    state is copied to the recipient on transmission (the ABM analogue
+    of `CloneDescendant`). Per-step Hamming-weight prevalence and
+    per-strain prevalence are both logged as long-form dataframes (one
+    row per `(Step, hw)` and `(Step, strain)`).
+
+    The vectorized deposit pattern is adapted from
+    https://github.com/mmore500/hstrat-synthesis (see `pylib/track_ca.py`).
+    """
+    )
+    return
+
+
+@app.cell
+def def_simulate(
+    Dict,
+    List,
+    Sequence,
+    Tuple,
+    Union,
+    dstream,
+    gc,
+    np,
+    pd,
+    random,
+    tqdm,
+    xp,
+):
+    def simulate(
+        N_SITES: int = 2,
+        POP_SIZE: int = 1_000_000,
+        CONTACT_RATE: float = 0.3,
+        RECOVERY_RATE: float = 0.1,
+        MUTATION_RATE: Union[float, Sequence[float]] = 1e-4,
+        WANING_RATE: float = 0.02,
+        IMMUNE_STRENGTH: float = 0.9,
+        N_STEPS: int = 1_000,
+        SEED_COUNT: int = 10,
+        within_host_b: float = 0.2,
+        within_host_t: float = 25.0,
+        seed: int = 1,
+        MUTATOR_HOSTS_N: int = 0,
+        MUTATOR_HOSTS_MX: float = 1.0,
+        MUTATION_THRESHOLD: float = 0.0,
+        IMMUNITY_CEILING: float = 1.0,
+        IMMUNITY_FLOOR: float = 0.0,
+        track_phylogeny: bool = False,
+        DSTREAM_S: int = 64,
+        DSTREAM_ALGO=None,
+        N_SAMPLE: int = 2000,
+        pow: float = 1.0,
+    ) -> Union[
+        Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame],
+        Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame],
+    ]:
+        random.seed(seed)
+        np.random.seed(seed)
+        xp.random.seed(seed)
+
+        if DSTREAM_ALGO is None:
+            DSTREAM_ALGO = dstream.hybrid_0_steady_1_tilted_2_algo
+
+        MUTATION_RATE = xp.asarray(MUTATION_RATE, dtype=xp.float32)
+
+        # Pick the smallest unsigned int dtype that holds `N_SITES` bits.
+        # 16/32/64-site sweeps round-trip through uint16/uint32/uint64
+        # without truncation; >64 would need a custom multi-word genome.
+        if N_SITES > 64:
+            raise NotImplementedError(
+                "current data types support only up to 64 sites",
+            )
+        elif N_SITES > 32:
+            genome_dtype = xp.uint64
+        elif N_SITES > 16:
+            genome_dtype = xp.uint32
+        else:
+            genome_dtype = xp.uint16
+
+        def initialize_pop() -> (
+            Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]
+        ):
+            """Initialize population statuses, genomes, and immune history."""
+            pathogen_genomes = xp.zeros(shape=POP_SIZE, dtype=genome_dtype)
+            host_immunities = xp.full(
+                shape=(POP_SIZE, 2 * N_SITES),
+                fill_value=0.0,
+                dtype=xp.float32,
+            )
+            host_statuses = xp.full(
+                shape=POP_SIZE, fill_value=0, dtype=xp.uint8
+            )
+            pathogen_markers = xp.random.randint(
+                low=0,
+                high=2**63,
+                size=POP_SIZE,
+                dtype=xp.int64,
+            ).astype(xp.uint64)
+            pathogen_markers |= xp.random.randint(
+                low=0,
+                high=2,
+                size=POP_SIZE,
+                dtype=xp.uint64,
+            ) << xp.uint64(63)
+            return (
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+            )
+
+        def infect_initial(
+            host_statuses: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+        ) -> Tuple[xp.ndarray, xp.ndarray]:
+            """Seed the initial infection wave with the starting strain."""
+            seeded_indices = xp.random.choice(
+                POP_SIZE, size=SEED_COUNT, replace=False
+            )
+            host_statuses[seeded_indices] = 1
+            pathogen_genomes[seeded_indices] = 0  # wildtype
+            return host_statuses, pathogen_genomes
+
+        def calc_infection_probabilities(
+            host_immunities: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+        ) -> xp.ndarray:
+            host_susceptibilities = xp.reshape(
+                1.0 - (IMMUNE_STRENGTH * host_immunities),
+                (POP_SIZE, 2 * N_SITES),
+            )
+
+            pathogen_bits = (
+                pathogen_genomes[:, None] >> xp.arange(N_SITES, dtype=xp.uint8)
+            ) & 1
+            pathogen_alleles = (
+                pathogen_bits[:, :, None] == xp.array([0, 1])
+            ).reshape(-1, 2 * N_SITES)
+
+            active_susc = xp.where(
+                pathogen_alleles, host_susceptibilities, 1.0
+            )
+            res = xp.prod(active_susc, axis=1)
+            assert res.shape == (POP_SIZE,)
+            return xp.pow(res, pow)
+
+        if MUTATION_RATE.size == 1:
+
+            def calc_mutation_probabilities(
+                host_immunities: xp.ndarray,
+                pathogen_genomes: xp.ndarray,
+            ) -> xp.ndarray:
+                pathogen_bits = (
+                    pathogen_genomes[:, None]
+                    >> xp.arange(N_SITES, dtype=xp.uint8)
+                ) & 1
+
+                imm_reshaped = xp.reshape(host_immunities, (-1, N_SITES, 2))
+
+                idx_curr = pathogen_bits[:, :, None]
+                idx_opp = 1 - idx_curr
+
+                imm_curr = xp.take_along_axis(
+                    imm_reshaped, idx_curr, axis=2
+                ).squeeze(axis=2)
+                imm_opp = xp.take_along_axis(
+                    imm_reshaped, idx_opp, axis=2
+                ).squeeze(axis=2)
+
+                host_immunity_deltas = imm_curr - imm_opp
+
+                b_values = 1.0 + within_host_b * host_immunity_deltas
+                b_values = xp.where(
+                    xp.abs(b_values - 1.0) < 1e-7, 1.000001, b_values
+                )
+
+                return (MUTATION_RATE / (b_values - 1.0)) * (
+                    xp.exp((b_values - 1.0) * within_host_t) - 1.0
+                )
+
+        else:
+
+            def calc_mutation_probabilities(
+                host_immunities: xp.ndarray,
+                pathogen_genomes: xp.ndarray,
+            ) -> xp.ndarray:
+                n_infected = host_immunities.shape[0]
+                return (
+                    xp.ones((n_infected, 1), dtype=MUTATION_RATE.dtype)
+                    * MUTATION_RATE
+                )
+
+        def update_waning(host_immunities: xp.ndarray) -> xp.ndarray:
+            host_immunities *= 1.0 - WANING_RATE
+            host_immunities[host_immunities > 0] = xp.clip(
+                host_immunities[host_immunities > 0],
+                IMMUNITY_FLOOR,
+                IMMUNITY_CEILING,
+            )
+            return host_immunities
+
+        def update_recoveries(
+            host_statuses: xp.ndarray,
+            host_immunities: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+        ) -> Tuple[xp.ndarray, xp.ndarray]:
+            recovered_mask = (host_statuses >= 1) * xp.random.rand(
+                POP_SIZE
+            ) > 1 - RECOVERY_RATE
+
+            pathogen_bits = (
+                pathogen_genomes[:, None] >> xp.arange(N_SITES, dtype=xp.uint8)
+            ) & 1
+            pathogen_alleles = (
+                pathogen_bits[:, :, None] == xp.array([0, 1])
+            ).reshape(-1, 2 * N_SITES)
+
+            assert np.all(
+                pathogen_alleles[recovered_mask].sum(axis=1) == N_SITES
+            )
+
+            host_immunities[
+                pathogen_alleles.astype(bool) & recovered_mask[:, None]
+            ] = 1.0
+
+            host_statuses += (host_statuses > 0).astype(xp.uint8)
+            host_statuses[recovered_mask] = 0
+
+            return host_statuses, host_immunities
+
+        def transmit_infection(
+            host_statuses: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+            host_immunities: xp.ndarray,
+            pathogen_markers: xp.ndarray,
+        ) -> Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]:
+            contacts = xp.random.randint(
+                low=0, high=POP_SIZE, size=POP_SIZE, dtype=xp.uint32
+            )
+            inf_probs = (
+                calc_infection_probabilities(
+                    host_immunities, pathogen_genomes[contacts]
+                )
+                * (host_statuses == 0)
+                * (host_statuses[contacts] > 0)
+                * CONTACT_RATE
+            )
+
+            new_infections = xp.random.rand(POP_SIZE) < inf_probs
+            host_statuses[new_infections] = 1
+            pathogen_genomes[new_infections] = pathogen_genomes[contacts][
+                new_infections
+            ]
+            pathogen_markers[new_infections] = pathogen_markers[contacts][
+                new_infections
+            ]
+
+            return (
+                host_statuses,
+                pathogen_genomes,
+                pathogen_markers,
+                new_infections,
+            )
+
+        def apply_mutations(
+            pathogen_genomes: xp.ndarray,
+            host_statuses: xp.ndarray,
+        ) -> xp.ndarray:
+            mutation_mask = (host_statuses == 1).astype(bool)
+
+            mprobs = calc_mutation_probabilities(
+                host_immunities[mutation_mask],
+                pathogen_genomes[mutation_mask],
+            )
+            mutator_n = host_statuses[:MUTATOR_HOSTS_N].sum()
+            mprobs[:mutator_n] = xp.minimum(
+                mprobs[:mutator_n] * MUTATOR_HOSTS_MX, 1.0
+            )
+
+            mprobs[mprobs < MUTATION_THRESHOLD] = 0.0
+
+            for s in range(N_SITES):
+                mutation_occurs = (
+                    xp.random.rand(mprobs.shape[0]) < mprobs[:, s]
+                ).astype(genome_dtype)
+                pathogen_genomes[mutation_mask] ^= (
+                    mutation_occurs << s
+                ).astype(genome_dtype)
+
+            return pathogen_genomes
+
+        def deposit_strata(
+            pathogen_markers: xp.ndarray,
+            t: int,
+        ) -> xp.ndarray:
+            site = DSTREAM_ALGO.assign_storage_site(DSTREAM_S, t + DSTREAM_S)
+            if site is None:
+                return pathogen_markers
+            new_bits = xp.random.randint(
+                0,
+                2,
+                size=POP_SIZE,
+                dtype=xp.uint64,
+            )
+            pathogen_markers ^= new_bits << np.uint64(63 - site)
+            return pathogen_markers
+
+        def update_simulation(
+            host_statuses: xp.ndarray,
+            pathogen_genomes: xp.ndarray,
+            host_immunities: xp.ndarray,
+            pathogen_markers: xp.ndarray,
+            t: int,
+        ) -> Tuple[xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray, xp.ndarray]:
+            (
+                host_statuses,
+                pathogen_genomes,
+                pathogen_markers,
+                new_infections,
+            ) = transmit_infection(
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+            )
+            new_strain_genomes = pathogen_genomes[new_infections].copy()
+            pathogen_genomes = apply_mutations(pathogen_genomes, host_statuses)
+            host_statuses, host_immunities = update_recoveries(
+                host_statuses, host_immunities, pathogen_genomes
+            )
+            host_immunities = update_waning(host_immunities)
+            pathogen_markers = deposit_strata(pathogen_markers, t)
+
+            return (
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+                new_strain_genomes,
+            )
+
+        (
+            host_statuses,
+            pathogen_genomes,
+            host_immunities,
+            pathogen_markers,
+        ) = initialize_pop()
+        host_statuses, pathogen_genomes = infect_initial(
+            host_statuses, pathogen_genomes
+        )
+        data_log: List[Dict[str, float]] = []
+        hw_log: List[Dict[str, float]] = []
+        strain_log: List[Dict[str, float]] = []
+        n_strains = 1 << N_SITES
+
+        # Precomputed per-(strain, site) susceptibility-column indices
+        # (a strain's allele bit at each site selects which of the two
+        # per-allele susc entries enters the per-strain product).
+        _strain_idx = xp.arange(n_strains, dtype=xp.int64)
+        _site_idx = xp.arange(N_SITES, dtype=xp.int64)
+        _strain_bits = (_strain_idx[:, None] >> _site_idx[None, :]) & 1
+        _strain_cols = (2 * _site_idx[None, :] + _strain_bits).astype(
+            xp.int64,
+        )
+
+        for t in tqdm(range(N_STEPS), mininterval=20.0):
+            (
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+                new_strain_genomes,
+            ) = update_simulation(
+                host_statuses,
+                pathogen_genomes,
+                host_immunities,
+                pathogen_markers,
+                t,
+            )
+
+            inf_mask = host_statuses > 0
+            hw_prevalences: List[float] = [0.0] * (N_SITES + 1)
+            # Raw case counts (number of currently-infected hosts) at
+            # each Hamming weight, i.e. the Hamming-weight prevalence
+            # expressed as a count of cases rather than a population
+            # fraction.
+            hw_case_counts: List[int] = [0] * (N_SITES + 1)
+            strain_prevalences: List[float] = [0.0] * n_strains
+
+            if xp.any(inf_mask):
+                infected_bits = (
+                    pathogen_genomes[inf_mask, None]
+                    >> xp.arange(N_SITES, dtype=xp.uint8)
+                ) & 1
+                hw_per_host = infected_bits.sum(axis=1).astype(xp.int64)
+                hw_counts_arr = xp.bincount(hw_per_host, minlength=N_SITES + 1)
+                _hw_counts_list = hw_counts_arr.tolist()
+                hw_case_counts = [int(c) for c in _hw_counts_list]
+                hw_prevalences = [float(c) / POP_SIZE for c in _hw_counts_list]
+
+                strain_per_host = pathogen_genomes[inf_mask].astype(xp.int64)
+                strain_counts_arr = xp.bincount(
+                    strain_per_host, minlength=n_strains
+                )
+                strain_prevalences = [
+                    float(c) / POP_SIZE for c in strain_counts_arr.tolist()
+                ]
+
+            # Per-strain new infections this step (population fraction).
+            # Captured pre-mutation in update_simulation so the strain
+            # label is the strain that actually transmitted.
+            if new_strain_genomes.size > 0:
+                new_strain_counts_arr = xp.bincount(
+                    new_strain_genomes.astype(xp.int64),
+                    minlength=n_strains,
+                )
+                new_strain_counts = [
+                    float(c) / POP_SIZE for c in new_strain_counts_arr.tolist()
+                ]
+            else:
+                new_strain_counts = [0.0] * n_strains
+
+            # Per-strain expected R per current infected per step:
+            # average over the population of P(strain s infects a random
+            # individual in one step). Currently-infected hosts
+            # contribute 0 since they cannot be re-infected --- the
+            # `(host_statuses == 0)` mask zeros out their per-host
+            # entries before averaging over the full POP_SIZE, so the
+            # mean already accounts for the susceptible-only fraction.
+            # Multiplying by n(s, t) gives the expected number of new
+            # strain-s infections per step. The dense
+            # (POP_SIZE, n_strains, N_SITES) tensor is skipped when it
+            # would exceed the cap (e.g. N_SITES >= 16 sweeps); the
+            # r-curves plot is also skipped for those conditions, so
+            # the all-zero column is never consumed downstream.
+            _expected_R_tensor_bytes = POP_SIZE * n_strains * N_SITES * 4
+            if _expected_R_tensor_bytes <= 2 * 1024**3:
+                host_susc_2d = (
+                    1.0 - (IMMUNE_STRENGTH * host_immunities)
+                ).reshape(POP_SIZE, 2 * N_SITES)
+                strain_susc_per_host = host_susc_2d[:, _strain_cols].prod(
+                    axis=2,
+                )
+                strain_susc_per_host = xp.power(strain_susc_per_host, pow)
+                strain_susc_per_host = (
+                    strain_susc_per_host * (host_statuses == 0)[:, None]
+                )
+                expected_R_per_strain = (
+                    strain_susc_per_host.mean(axis=0) * CONTACT_RATE
+                )
+                expected_R_list = [
+                    float(x) for x in expected_R_per_strain.tolist()
+                ]
+            else:
+                expected_R_list = [0.0] * n_strains
+
+            for w, count in enumerate(hw_prevalences):
+                hw_log.append(
+                    {
+                        "Step": t,
+                        "Seed": seed,
+                        "hw": w,
+                        "count": count,
+                        "n_cases": hw_case_counts[w],
+                    }
+                )
+
+            for s, count in enumerate(strain_prevalences):
+                strain_log.append(
+                    {
+                        "Step": t,
+                        "Seed": seed,
+                        "strain": s,
+                        "count": count,
+                        "new_infections": new_strain_counts[s],
+                        "expected_R": expected_R_list[s],
+                    }
+                )
+
+            avg_susc = xp.mean(
+                (1.0 - (IMMUNE_STRENGTH * host_immunities))
+                * (host_statuses == 0)[:, None],
+                axis=0,
+            )
+
+            immunity_dict = {}
+            for i in range(2 * N_SITES):
+                site = i // 2
+                bit = i % 2
+                immunity_dict[f"Susc_S{site}_B{bit}"] = float(avg_susc[i])
+
+            log_entry = {
+                "Step": t,
+                "Seed": seed,
+                "Total_Infected": float(xp.sum(inf_mask)) / POP_SIZE,
+            }
+            log_entry.update(immunity_dict)
+            data_log.append(log_entry)
+
+        df = pd.DataFrame(data_log).fillna(0).copy()
+        hw_df = pd.DataFrame(hw_log)
+        strain_df = pd.DataFrame(strain_log)
+        if not track_phylogeny:
+            return df, hw_df, strain_df
+
+        algo_name = f"dstream.{DSTREAM_ALGO.__name__}"
+        S = DSTREAM_S
+        T_bitwidth = 32
+        bitwidth = 1
+        bytes_per_T = T_bitwidth // 8
+        bytes_per_storage = S * bitwidth // 8
+        bytes_per_row = bytes_per_T + bytes_per_storage
+        empty_records = pd.DataFrame(
+            {
+                "data_hex": pd.Series([], dtype=str),
+                "dstream_algo": pd.Series([], dtype=str),
+                "dstream_storage_bitoffset": pd.Series([], dtype="int64"),
+                "dstream_storage_bitwidth": pd.Series([], dtype="int64"),
+                "dstream_T_bitoffset": pd.Series([], dtype="int64"),
+                "dstream_T_bitwidth": pd.Series([], dtype="int64"),
+                "dstream_S": pd.Series([], dtype="int64"),
+                "extant": pd.Series([], dtype=bool),
+                "snapshot_step": pd.Series([], dtype="int64"),
+                "genome": pd.Series([], dtype="int64"),
+                "taxon_id": pd.Series([], dtype="int64"),
+            },
+        )
+        infected_idx = xp.where(host_statuses > 0)[0]
+        n_inf = int(infected_idx.size)
+        if n_inf == 0:
+            return df, hw_df, strain_df, empty_records
+
+        n_sample = min(N_SAMPLE, n_inf)
+        sampled = (
+            xp.random.choice(infected_idx, size=n_sample, replace=False)
+            if n_sample < n_inf
+            else infected_idx
+        )
+
+        # CUPY SUPPORT: Transfer to host if using GPU
+        _to_np = (lambda a: np.asarray(a)) if xp is np else (lambda a: a.get())
+        sampled_markers = _to_np(pathogen_markers[sampled])
+        sampled_genomes = _to_np(pathogen_genomes[sampled])
+        # Rank includes implicit predeposits
+        sampled_steps = np.full(n_sample, N_STEPS + DSTREAM_S, dtype=np.uint32)
+        sampled_taxon_ids = np.arange(n_sample, dtype=np.int64)
+
+        T_bytes_hex = sampled_steps.astype(">u4").tobytes().hex()
+        marker_bytes_hex = sampled_markers.astype(">u8").tobytes().hex()
+        data_hex = [
+            (
+                T_bytes_hex[i * bytes_per_T * 2 : (i + 1) * bytes_per_T * 2]
+                + marker_bytes_hex[
+                    i * bytes_per_storage * 2 : (i + 1) * bytes_per_storage * 2
+                ]
+            )
+            for i in range(n_sample)
+        ]
+
+        records_df = pd.DataFrame(
+            {
+                "data_hex": data_hex,
+                "dstream_algo": algo_name,
+                "dstream_storage_bitoffset": bytes_per_T * 8,
+                "dstream_storage_bitwidth": bytes_per_storage * 8,
+                "dstream_T_bitoffset": 0,
+                "dstream_T_bitwidth": T_bitwidth,
+                "dstream_S": S,
+                "extant": True,
+                "snapshot_step": sampled_steps.astype(np.int64),
+                "genome": sampled_genomes.astype(np.int64),
+                "taxon_id": sampled_taxon_ids,
+            }
+        )
+        assert all(len(h) == bytes_per_row * 2 for h in data_hex), (
+            f"hex length mismatch (expected {bytes_per_row * 2}, "
+            f"got {set(len(h) for h in data_hex)})"
+        )
+        del data_hex, T_bytes_hex, marker_bytes_hex
+        gc.collect()
+        return df, hw_df, strain_df, records_df
+
+    return (simulate,)
+
+
+@app.cell(hide_code=True)
+def delimit_reconstruct(mo):
+    mo.md(
+        """
+    ## Surface-Annotation Reconstruction
+
+    Given the snapshot records emitted by `simulate(..., track_phylogeny=
+    True)`, run `hstrat.dataframe.surface_unpack_reconstruct` followed by
+    `hstrat.dataframe.surface_postprocess_trie` to estimate the phylogenetic
+    tree. We use `AssignOriginTimeNodeRankTriePostprocessor(t0="dstream_S")`
+    so that origin times line up with simulation step numbers.
+    """
+    )
+    return
+
+
+@app.cell
+def def_reconstruct_phylogeny(gc, hstrat, pd, pl):
+    def reconstruct_phylogeny(
+        records_df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        in_df = pl.from_pandas(records_df)
+        post = hstrat.dataframe.surface_build_tree(
+            in_df,
+            trie_postprocessor=(
+                hstrat.phylogenetic_inference.AssignOriginTimeNodeRankTriePostprocessor(
+                    t0="dstream_S",
+                )
+            ),
+        ).to_pandas()
+        gc.collect()
+        for col in ("id", "ancestor_id"):
+            if col in post.columns:
+                post[col] = post[col].astype("int64")
+        post["extant"] = post["extant"].fillna(False).astype(bool)
+        for col in ("snapshot_step", "genome", "origin_time"):
+            if col in post.columns:
+                post[col] = pd.to_numeric(post[col], errors="coerce")
+        return post
+
+    return (reconstruct_phylogeny,)
+
+
+@app.cell(hide_code=True)
+def delimit_phylogeny(mo):
+    mo.md(
+        """
+    ## Surface-Reconstructed Phylogeny
+
+    Sweep `N_SITES` over a few values and render the surface-reconstructed
+    phylogeny next to the absolute-prevalence and Hamming-weight stackplots.
+    """
+    )
+    return
+
+
+@app.cell
+def def_make_phylogeny_plot(
+    FuncFormatter,
+    MaxNLocator,
+    draw_scatter_tree,
+    np,
+    pathlib,
+    pd,
+    pfl,
+    plt,
+    sns,
+    tp,
+):
+    def make_phylogeny_plot(
+        N_SITES: int,
+        phylo_df,
+        hw_df,
+        phylogeny_df,
+        max_tips: int = 10_000,
+        seed: int = 0,
+        palette: str = "rocket_r",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        pruned_df = (
+            pfl.alifestd_downsample_tips_uniform_asexual(
+                phylogeny_df,
+                n_downsample=max_tips,
+                seed=0,
+            )
+            .pipe(pfl.alifestd_add_global_root, root_attrs={"origin_time": 0})
+            .pipe(pfl.alifestd_collapse_unifurcations)
+            .pipe(pfl.alifestd_try_add_ancestor_list_col)
+            .pipe(pfl.alifestd_ladderize_asexual)
+            .pipe(pfl.alifestd_assign_contiguous_ids)
+        )
+        assert pfl.alifestd_validate(pruned_df)
+        print(f"  downsampled tree: {len(pruned_df)} nodes")
+        print(f"  leaf count: {pfl.alifestd_count_leaf_nodes(pruned_df)}")
+
+        pruned_df = pruned_df.assign(
+            hw=pruned_df["genome"].map(
+                lambda g: None if pd.isna(g) else bin(int(g)).count("1"),
+            ),
+        )
+        pruned_df = pruned_df.assign(
+            hw_label=pruned_df["hw"].map(
+                lambda w: None if pd.isna(w) else f"HW {int(w)}"
+            ),
+        )
+
+        hw_values = list(range(N_SITES + 1))
+        hw_palette = sns.color_palette(palette, len(hw_values))
+
+        present_hw = sorted(int(w) for w in hw_df["hw"].unique())
+        hw_labels = [f"HW {w}" for w in present_hw]
+        plot_df = hw_df.assign(
+            y=-hw_df["Step"],
+            hw_label=hw_df["hw"].map(lambda w: f"HW {int(w)}"),
+        )
+        plot_df = plot_df[plot_df["count"] > 0]
+
+        if len(present_hw) > 4:
+            _idx = np.unique(
+                np.linspace(0, len(present_hw) - 1, 4).round().astype(int)
+            ).tolist()
+        else:
+            _idx = list(range(len(present_hw)))
+        hw_legend_entries = [(present_hw[i], hw_labels[i]) for i in _idx]
+
+        def _hw_handle(w, label):
+            return plt.Line2D(
+                [0],
+                [0],
+                marker="s",
+                color="w",
+                markerfacecolor=hw_palette[w],
+                markersize=10,
+                label=label,
+            )
+
+        hw_palette_map = {f"HW {w}": hw_palette[w] for w in present_hw}
+
+        with tp.teed(
+            plt.subplots,
+            nrows=1,
+            ncols=3,
+            figsize=(8, 6),
+            gridspec_kw={
+                "width_ratios": [1.4, 1.0, 1.0],
+                "wspace": 0.1,
+            },
+            sharey=True,
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_tree, ax_strain, ax_hw = axes
+
+            sns.histplot(
+                data=plot_df,
+                y="y",
+                hue="hw_label",
+                hue_order=hw_labels,
+                weights="count",
+                binwidth=phylo_df["Step"].diff().min(),
+                multiple="stack",
+                stat="count",
+                element="poly",
+                palette=hw_palette_map,
+                ax=ax_strain,
+                fill=True,
+                linewidth=0,
+                legend=False,
+            )
+            _band_xs = [
+                c.get_paths()[0].vertices[:, 0].max()
+                for c in ax_strain.collections
+                if c.get_paths()
+            ]
+            if _band_xs:
+                _peak = max(_band_xs)
+                _lo, _ = ax_strain.get_xlim()
+                ax_strain.set_xlim(_lo, _peak * 1.05)
+
+            sns.kdeplot(
+                data=plot_df,
+                y="y",
+                hue="hw_label",
+                hue_order=hw_labels,
+                weights="count",
+                multiple="fill",
+                common_norm=True,
+                cut=0,
+                palette=hw_palette_map,
+                ax=ax_hw,
+                fill=True,
+                linewidth=0,
+                legend=False,
+                bw_adjust=0.5,
+            )
+
+            for ax in (ax_strain, ax_hw):
+                ax.set_xlabel("")
+            ax_hw.set_xlim(0, 1)
+
+            ax_tree.set_ylabel("step")
+            ax_tree.tick_params(left=True, labelleft=True)
+            for ax in (ax_strain, ax_hw):
+                ax.tick_params(labelleft=False, left=False)
+                ax.xaxis.tick_top()
+                ax.xaxis.set_label_position("top")
+
+            ax_tree.tick_params(bottom=False, labelbottom=False)
+            sns.despine(ax=ax_strain, left=True, bottom=True, top=False)
+            sns.despine(ax=ax_hw, left=True, bottom=True, top=False)
+
+            ax_hw.legend(
+                handles=[
+                    _hw_handle(w, label) for w, label in hw_legend_entries
+                ],
+                title="Hamming weight",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+            )
+
+            draw_scatter_tree(
+                pruned_df.reset_index(drop=True),
+                ax=ax_tree,
+                hue="hw_label",
+                scatter_kws=dict(
+                    legend=False,
+                    palette=hw_palette_map,
+                ),
+                tree_kws=dict(
+                    edge_color="gray",
+                    edge_linewidth=0.7,
+                    edge_zorder=1,
+                    ladderize=True,
+                ),
+            )
+            sns.despine(ax=ax_tree, top=True, right=True, bottom=True)
+            ax_tree.set_ylim(ax_hw.get_ylim())
+            ax_tree.set_aspect("auto")
+            ax_tree.yaxis.set_major_locator(MaxNLocator(integer=True))
+            ax_tree.yaxis.set_major_formatter(
+                FuncFormatter(lambda x, _: f"{abs(int(round(x)))}"),
+            )
+
+    return (make_phylogeny_plot,)
+
+
+@app.cell
+def def_make_strain_graph_plot(ig, iplotx, np, pathlib, plt, sns, tp):
+    def make_strain_graph_plot(
+        N_SITES: int,
+        records_df,
+        max_n: int = 4,
+        palette: str = "rocket_r",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Plot final-step strains as undirected graphs at thresholds n=1..max_n.
+
+        Nodes are unique strains (sized by population copies, colored by
+        Hamming weight, 80% alpha). Edges connect strains within Hamming
+        distance ``n``. For ``n > 1`` only edges that are not implicitly
+        present via a 2-hop path through previously-added edges are drawn,
+        with line thickness encoding the threshold ``n`` at which the edge
+        was introduced.
+        """
+        extant = records_df[records_df["extant"]].copy()
+        if len(extant) == 0:
+            print("  (no extant records --- skipping strain graph plot)")
+            return
+
+        genomes = extant["genome"].astype("int64").to_numpy()
+        strains, counts = np.unique(genomes, return_counts=True)
+        n_strains = int(strains.size)
+        if n_strains < 2:
+            print(
+                f"  (only {n_strains} strain --- skipping strain graph plot)"
+            )
+            return
+
+        hamming_weights = np.array(
+            [bin(int(s)).count("1") for s in strains], dtype=int
+        )
+
+        xor = strains[:, None] ^ strains[None, :]
+        dists = np.zeros_like(xor, dtype=np.int32)
+        tmp = xor.copy()
+        while tmp.any():
+            dists += (tmp & 1).astype(np.int32)
+            tmp >>= 1
+
+        cumulative = {}  # (i, j) with i < j -> threshold n at which added
+        adjacency = [set() for _ in range(n_strains)]
+        snapshots = []
+        for n in range(1, max_n + 1):
+            iu, ju = np.where(np.triu(dists == n, k=1))
+            for i, j in zip(iu.tolist(), ju.tolist()):
+                if n > 1 and adjacency[i] & adjacency[j]:
+                    continue
+                cumulative[(i, j)] = n
+                adjacency[i].add(j)
+                adjacency[j].add(i)
+            snapshots.append((n, dict(cumulative)))
+
+        palette_colors = sns.color_palette(palette, N_SITES + 1)
+        node_facecolors = [
+            (*palette_colors[int(hw)], 0.8) for hw in hamming_weights
+        ]
+
+        max_count = int(counts.max())
+        sizes = 4.0 + 18.0 * np.sqrt(counts / max_count)
+
+        # Label only the dominant strains: those carrying more than 10% of
+        # the sampled population, annotated with their Hamming weight.
+        total = int(counts.sum())
+        vertex_labels = [
+            str(int(hamming_weights[i])) if counts[i] > 0.10 * total else ""
+            for i in range(n_strains)
+        ]
+
+        # Layout: kamada_kawai on the densest graph (max_n) so vertex
+        # positions are stable across subplots.
+        ref_graph = ig.Graph(n=n_strains)
+        ref_graph.add_edges(list(cumulative.keys()))
+        if ref_graph.ecount() > 0:
+            try:
+                layout = ref_graph.layout_kamada_kawai()
+            except Exception:
+                layout = ref_graph.layout_fruchterman_reingold()
+        else:
+            layout = ref_graph.layout_circle()
+        layout_coords = [tuple(c) for c in layout.coords]
+
+        with tp.teed(
+            plt.subplots,
+            nrows=1,
+            ncols=max_n,
+            figsize=(4.5 * max_n, 4.5),
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            if max_n == 1:
+                axes = [axes]
+
+            for ax, (n, edges_dict) in zip(axes, snapshots):
+                edges = list(edges_dict.keys())
+                # 1-hop edges thickest, with progressively thinner widths
+                # for higher-n edges; n>1 edges drawn dashed to distinguish
+                # them from direct mutational neighbors.
+                widths = [3.0 / edges_dict[e] for e in edges]
+                linestyles = [
+                    "-" if edges_dict[e] == 1 else "--" for e in edges
+                ]
+
+                g_plot = ig.Graph(n=n_strains)
+                if edges:
+                    g_plot.add_edges(edges)
+
+                iplotx.network(
+                    g_plot,
+                    layout=layout_coords,
+                    vertex_facecolor=node_facecolors,
+                    vertex_edgecolor="black",
+                    vertex_size=sizes.tolist(),
+                    vertex_labels=vertex_labels,
+                    vertex_label_color="black",
+                    vertex_label_size=8,
+                    edge_linewidth=widths if widths else 1.0,
+                    edge_linestyle=linestyles if linestyles else "-",
+                    edge_color="gray",
+                    ax=ax,
+                    show=False,
+                )
+                ax.set_title(f"n = {n}")
+                ax.set_aspect("equal")
+
+            # Match make_phylogeny_plot's legend: span the same HW limits
+            # (min/max of present Hamming weights), with up to 4
+            # evenly-spaced entries.
+            present_hw = sorted(int(w) for w in set(hamming_weights.tolist()))
+            if len(present_hw) > 4:
+                idx = np.unique(
+                    np.linspace(0, len(present_hw) - 1, 4).round().astype(int)
+                ).tolist()
+                legend_hw = [present_hw[i] for i in idx]
+            else:
+                legend_hw = present_hw
+
+            handles = [
+                plt.Line2D(
+                    [0],
+                    [0],
+                    marker="o",
+                    color="w",
+                    markerfacecolor=(*palette_colors[w], 0.8),
+                    markeredgecolor="black",
+                    markersize=10,
+                    label=f"HW {w}",
+                )
+                for w in legend_hw
+            ]
+            axes[-1].legend(
+                handles=handles,
+                title="Hamming weight",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+            )
+
+    return (make_strain_graph_plot,)
+
+
+@app.cell
+def def_make_strain_curves_plot(np, pathlib, plt, sns, strain_palette, tp):
+    def make_strain_curves_plot(
+        N_SITES: int,
+        traj_df,
+        strain_df,
+        palette: str = "husl",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Two-panel stacked figure: top = per-strain population-average
+        susceptibility (dashed), bottom = per-strain prevalence (solid).
+        Strains are color-coded by Hamming weight (hue) with lightness
+        disambiguating strains that share a Hamming weight.
+        """
+        n_strains = 1 << N_SITES
+        steps = traj_df["Step"].to_numpy()
+
+        susc_by_site_bit = np.empty((len(traj_df), N_SITES, 2), dtype=float)
+        for site in range(N_SITES):
+            for bit in range(2):
+                susc_by_site_bit[:, site, bit] = traj_df[
+                    f"Susc_S{site}_B{bit}"
+                ].to_numpy()
+
+        # Susceptibility to strain s = product over sites of Susc_S{site}_B{bit}
+        # where `bit` is the allele of strain s at that site.
+        susc_per_strain = np.ones((len(traj_df), n_strains), dtype=float)
+        for s in range(n_strains):
+            for site in range(N_SITES):
+                bit = (s >> site) & 1
+                susc_per_strain[:, s] *= susc_by_site_bit[:, site, bit]
+
+        palette_colors = strain_palette(N_SITES, base_palette=palette)
+
+        with tp.teed(
+            plt.subplots,
+            nrows=2,
+            ncols=1,
+            figsize=(8, 6),
+            sharex=True,
+            gridspec_kw={"hspace": 0.05},
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_susc, ax_prev = axes
+
+            for s in range(n_strains):
+                color = palette_colors[s]
+                label = f"{s:0{N_SITES}b}"
+                ax_susc.plot(
+                    steps,
+                    susc_per_strain[:, s],
+                    color=color,
+                    linestyle="--",
+                    linewidth=1.5,
+                    label=label,
+                )
+
+                strain_s = strain_df[strain_df["strain"] == s]
+                strain_s = strain_s.sort_values("Step")
+                ax_prev.plot(
+                    strain_s["Step"].to_numpy(),
+                    strain_s["count"].to_numpy(),
+                    color=color,
+                    linestyle="-",
+                    linewidth=1.5,
+                    label=label,
+                )
+
+            ax_susc.set_ylabel("Population Susceptibility")
+            ax_susc.set_ylim(0.0, 1.0)
+            ax_prev.set_ylabel("Case Burden")
+            ax_prev.set_xlabel("Time")
+            ax_prev.set_ylim(bottom=0.0)
+
+            ax_susc.legend(
+                title="strain",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1 if n_strains <= 8 else 2,
+                fontsize=8,
+            )
+            sns.despine(ax=ax_susc)
+            sns.despine(ax=ax_prev)
+
+    return (make_strain_curves_plot,)
+
+
+@app.cell
+def def_make_strain_summary_plot(np, pathlib, plt, sns, strain_palette, tp):
+    def make_strain_summary_plot(
+        N_SITES: int,
+        traj_df,
+        strain_df,
+        RECOVERY_RATE: float,
+        palette: str = "husl",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Three-panel stacked figure: top = per-strain expected R
+        (R0-like, dotted), middle = per-strain population-average
+        susceptibility (dashed), bottom = per-strain prevalence
+        ("case load", solid). Expected R is `strain_df["expected_R"]`
+        scaled by the discrete-time R0 multiplier
+        `(1 - RECOVERY_RATE) / RECOVERY_RATE` (see make_r_curves_plot
+        for the off-by-one rationale). Strains are color-coded by
+        Hamming weight (hue) with lightness disambiguating strains
+        of the same weight; R = 1 is drawn as a reference line.
+        """
+        n_strains = 1 << N_SITES
+        steps = traj_df["Step"].to_numpy()
+
+        susc_by_site_bit = np.empty((len(traj_df), N_SITES, 2), dtype=float)
+        for site in range(N_SITES):
+            for bit in range(2):
+                susc_by_site_bit[:, site, bit] = traj_df[
+                    f"Susc_S{site}_B{bit}"
+                ].to_numpy()
+        susc_per_strain = np.ones((len(traj_df), n_strains), dtype=float)
+        for s in range(n_strains):
+            for site in range(N_SITES):
+                bit = (s >> site) & 1
+                susc_per_strain[:, s] *= susc_by_site_bit[:, site, bit]
+
+        unique_steps = np.array(
+            sorted(strain_df["Step"].unique()), dtype=float
+        )
+        T = len(unique_steps)
+        step_to_idx = {t: i for i, t in enumerate(unique_steps.tolist())}
+        expected_R_per_strain = np.zeros((T, n_strains), dtype=float)
+        for _, row in strain_df.iterrows():
+            i = step_to_idx[row["Step"]]
+            s = int(row["strain"])
+            expected_R_per_strain[i, s] = float(row.get("expected_R", 0.0))
+        r0_multiplier = (1.0 - RECOVERY_RATE) / RECOVERY_RATE
+        expected_R_per_strain = expected_R_per_strain * r0_multiplier
+
+        palette_colors = strain_palette(N_SITES, base_palette=palette)
+
+        with tp.teed(
+            plt.subplots,
+            nrows=3,
+            ncols=1,
+            figsize=(8, 8),
+            sharex=True,
+            gridspec_kw={"hspace": 0.05},
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_r, ax_susc, ax_prev = axes
+
+            for s in range(n_strains):
+                color = palette_colors[s]
+                label = f"{s:0{N_SITES}b}"
+                ax_r.plot(
+                    unique_steps,
+                    expected_R_per_strain[:, s],
+                    color=color,
+                    linestyle=":",
+                    linewidth=1.5,
+                    label=label,
+                )
+                ax_susc.plot(
+                    steps,
+                    susc_per_strain[:, s],
+                    color=color,
+                    linestyle="--",
+                    linewidth=1.5,
+                )
+                strain_s = strain_df[strain_df["strain"] == s]
+                strain_s = strain_s.sort_values("Step")
+                ax_prev.plot(
+                    strain_s["Step"].to_numpy(),
+                    strain_s["count"].to_numpy(),
+                    color=color,
+                    linestyle="-",
+                    linewidth=1.5,
+                )
+
+            ax_r.axhline(1.0, color="gray", linestyle=":", linewidth=0.8)
+            ax_r.set_ylabel("expected R")
+            ax_r.set_ylim(bottom=0.0)
+            ax_susc.set_ylabel("Population Susceptibility")
+            ax_susc.set_ylim(0.0, 1.0)
+            ax_prev.set_ylabel("Case Load")
+            ax_prev.set_xlabel("Time")
+            ax_prev.set_ylim(bottom=0.0)
+
+            ax_r.legend(
+                title="strain",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1 if n_strains <= 8 else 2,
+                fontsize=8,
+            )
+            sns.despine(ax=ax_r)
+            sns.despine(ax=ax_susc)
+            sns.despine(ax=ax_prev)
+
+    return (make_strain_summary_plot,)
+
+
+@app.cell
+def def_make_allele_curves_plot(allele_palette, np, pathlib, plt, sns, tp):
+    def make_allele_curves_plot(
+        N_SITES: int,
+        traj_df,
+        strain_df,
+        palette: str = "husl",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Two-panel stacked figure aggregated by individual allele:
+        top = per-(site, allele) population-average susceptibility
+        (dashed); bottom = per-(site, allele) prevalence (solid). Each
+        site gets its own ggplot-style HCL hue; the two alleles within
+        a site are split by lightness (allele 0 darker, allele 1 lighter).
+        """
+        n_strains = 1 << N_SITES
+        steps = traj_df["Step"].to_numpy()
+
+        # Per-(site, allele) susceptibility comes straight from the
+        # `Susc_S{site}_B{bit}` columns logged by simulate().
+        susc_per_allele = np.empty((len(traj_df), N_SITES, 2), dtype=float)
+        for site in range(N_SITES):
+            for bit in range(2):
+                susc_per_allele[:, site, bit] = traj_df[
+                    f"Susc_S{site}_B{bit}"
+                ].to_numpy()
+
+        # Per-(site, allele) prevalence is the sum of strain prevalences
+        # over strains carrying that allele at that site.
+        unique_steps = sorted(strain_df["Step"].unique())
+        step_to_idx = {t: i for i, t in enumerate(unique_steps)}
+        prev_per_allele = np.zeros(
+            (len(unique_steps), N_SITES, 2), dtype=float
+        )
+        for s in range(n_strains):
+            sub = strain_df[strain_df["strain"] == s]
+            for _, row in sub.iterrows():
+                idx = step_to_idx[row["Step"]]
+                count = float(row["count"])
+                for site in range(N_SITES):
+                    bit = (s >> site) & 1
+                    prev_per_allele[idx, site, bit] += count
+
+        site_allele_to_color = allele_palette(N_SITES, base_palette=palette)
+
+        with tp.teed(
+            plt.subplots,
+            nrows=2,
+            ncols=1,
+            figsize=(8, 6),
+            sharex=True,
+            gridspec_kw={"hspace": 0.05},
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_susc, ax_prev = axes
+
+            for site in range(N_SITES):
+                for allele in (0, 1):
+                    color = site_allele_to_color[(site, allele)]
+                    label = f"S{site}A{allele}"
+                    ax_susc.plot(
+                        steps,
+                        susc_per_allele[:, site, allele],
+                        color=color,
+                        linestyle="--",
+                        linewidth=1.5,
+                        label=label,
+                    )
+                    ax_prev.plot(
+                        unique_steps,
+                        prev_per_allele[:, site, allele],
+                        color=color,
+                        linestyle="-",
+                        linewidth=1.5,
+                        label=label,
+                    )
+
+            ax_susc.set_ylabel("Population Susceptibility")
+            ax_susc.set_ylim(0.0, 1.0)
+            ax_prev.set_ylabel("Case Burden")
+            ax_prev.set_xlabel("Time")
+            ax_prev.set_ylim(bottom=0.0)
+
+            ax_susc.legend(
+                title="site / allele",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1,
+                fontsize=8,
+            )
+            sns.despine(ax=ax_susc)
+            sns.despine(ax=ax_prev)
+
+    return (make_allele_curves_plot,)
+
+
+@app.cell
+def def_make_r_curves_plot(np, pathlib, pd, plt, sns, strain_palette, tp):
+    def make_r_curves_plot(
+        N_SITES: int,
+        strain_df,
+        RECOVERY_RATE: float,
+        smoothing_windows=(1, 5, 25, 125),
+        palette: str = "husl",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Multi-row figure of per-strain reproduction number. The
+        first row plots the *expected* R per strain on its own; each
+        subsequent row plots the *actual* R per strain at a
+        different rolling-mean window (unsmoothed first). Both per-
+        step rates are scaled by the discrete-time R0 multiplier
+        `(1 - RECOVERY_RATE) / RECOVERY_RATE` so the plotted values
+        are the expected number of total transmissions caused by a
+        single primary infection (an `R0`-like quantity) rather than
+        the per-step rate. The factor is `(1 - p) / p` rather than
+        `1 / p` because `update_recoveries` runs after
+        `transmit_infection` within the same step, so a just-infected
+        primary faces an immediate recovery check before it can
+        transmit at the next step.
+
+        * actual R(t, s) = (new_infections(s, t) /
+          n_with_strain(s, t)) * (1 - RECOVERY_RATE) / RECOVERY_RATE.
+          Rolling-mean smoothed with the row's window.
+        * expected R(t, s) = expected_R_per_step(s, t) *
+          (1 - RECOVERY_RATE) / RECOVERY_RATE, where the per-step
+          quantity is the population-average probability that strain
+          s infects a randomly-sampled individual on a single contact
+          in one step (logged per step as `strain_df["expected_R"]`,
+          with currently-infected hosts contributing 0 since they
+          cannot be re-infected). Plotted unsmoothed since it is
+          already a smooth function of population state.
+
+        Strains are color-coded by Hamming weight (hue) with
+        lightness disambiguating strains of the same weight. The
+        epidemic threshold R = 1 is drawn as a dotted reference line.
+        """
+        n_strains = 1 << N_SITES
+
+        unique_steps = np.array(
+            sorted(strain_df["Step"].unique()), dtype=float
+        )
+        T = len(unique_steps)
+        step_to_idx = {t: i for i, t in enumerate(unique_steps.tolist())}
+
+        prev_per_strain = np.zeros((T, n_strains), dtype=float)
+        new_inf_per_strain = np.zeros((T, n_strains), dtype=float)
+        expected_R_per_strain = np.zeros((T, n_strains), dtype=float)
+
+        for _, row in strain_df.iterrows():
+            i = step_to_idx[row["Step"]]
+            s = int(row["strain"])
+            prev_per_strain[i, s] = float(row["count"])
+            new_inf_per_strain[i, s] = float(row.get("new_infections", 0.0))
+            expected_R_per_strain[i, s] = float(row.get("expected_R", 0.0))
+
+        # Convert per-step rates to per-primary R0-like totals. A
+        # primary newly infected in step t's transmit_infection faces
+        # update_recoveries in the same step, so it participates as a
+        # source in step t+1 only with prob (1 - p), in step t+2 with
+        # prob (1 - p)^2, etc. The expected number of future
+        # transmit_infection participations is therefore
+        # sum_{k=1}^inf (1-p)^k = (1 - p) / p, NOT 1 / p (off-by-one
+        # if you forget that update_recoveries runs after
+        # transmit_infection within the same step).
+        r0_multiplier = (1.0 - RECOVERY_RATE) / RECOVERY_RATE
+        expected_R_per_strain = expected_R_per_strain * r0_multiplier
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            r_actual_per_strain = np.where(
+                prev_per_strain > 0,
+                new_inf_per_strain / prev_per_strain,
+                np.nan,
+            )
+        r_actual_per_strain = r_actual_per_strain * r0_multiplier
+
+        palette_colors = strain_palette(N_SITES, base_palette=palette)
+
+        windows = list(smoothing_windows)
+        if not windows or windows[0] != 1:
+            windows = [1] + windows
+
+        n_rows = 1 + len(windows)
+
+        with tp.teed(
+            plt.subplots,
+            nrows=n_rows,
+            ncols=1,
+            figsize=(8, 2.0 * n_rows + 1.0),
+            sharex=True,
+            gridspec_kw={"hspace": 0.08},
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, axes):
+            ax_expected = axes[0]
+            actual_axes = axes[1:]
+
+            for s in range(n_strains):
+                color = palette_colors[s]
+                label = f"{s:0{N_SITES}b}"
+                ax_expected.plot(
+                    unique_steps,
+                    expected_R_per_strain[:, s],
+                    color=color,
+                    linestyle="--",
+                    linewidth=1.5,
+                    label=label,
+                )
+            ax_expected.axhline(
+                1.0, color="gray", linestyle=":", linewidth=0.8
+            )
+            ax_expected.set_ylabel("expected R")
+            ax_expected.set_ylim(bottom=0.0)
+            sns.despine(ax=ax_expected)
+
+            ax_expected.legend(
+                title="strain",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1 if n_strains <= 8 else 2,
+                fontsize=8,
+            )
+
+            for ax, w in zip(actual_axes, windows):
+                for s in range(n_strains):
+                    color = palette_colors[s]
+                    actual = pd.Series(r_actual_per_strain[:, s])
+                    if w > 1:
+                        actual = actual.rolling(
+                            window=w,
+                            min_periods=max(1, w // 4),
+                            center=True,
+                        ).mean()
+                    ax.plot(
+                        unique_steps,
+                        actual.to_numpy(),
+                        color=color,
+                        linestyle="-",
+                        linewidth=1.2,
+                    )
+                ax.axhline(1.0, color="gray", linestyle=":", linewidth=0.8)
+                ax.set_ylabel(f"actual R\nrolling window = {w}")
+                sns.despine(ax=ax)
+
+            actual_axes[-1].set_xlabel("Time")
+
+    return (make_r_curves_plot,)
+
+
+@app.cell
+def def_make_density_heatmap_plot(np, pathlib, plt, sns, tp):
+    import matplotlib.colors as mcolors
+
+    def make_density_heatmap_plot(
+        N_SITES: int,
+        strain_df,
+        cmap: str = "rocket_r",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Heatmap of population density binned by Hamming distance to
+        the end-state most populous strain. y-axis is the number of
+        bits in common with that reference strain (top = identical
+        with the end-state strain, bottom = its complement); x-axis is
+        time. Each column is normalized to sum to 1, so cells encode
+        the proportion of *circulating* strains (not the host
+        population fraction) sharing the given number of bits with the
+        reference at the given step. The colormap is truncated and
+        true-zero cells are masked white so that barely-positive bins
+        are clearly distinguishable from empty bins.
+        """
+        n_strains = 1 << N_SITES
+
+        unique_steps = np.array(
+            sorted(strain_df["Step"].unique()), dtype=np.int64
+        )
+        T = len(unique_steps)
+        final_step = int(unique_steps.max())
+
+        final = strain_df[strain_df["Step"] == final_step]
+        end_strain = int(final.loc[final["count"].idxmax(), "strain"])
+
+        bits_in_common = N_SITES - np.array(
+            [bin(int(s) ^ end_strain).count("1") for s in range(n_strains)],
+            dtype=np.int64,
+        )
+
+        strains_arr = strain_df["strain"].to_numpy().astype(np.int64)
+        steps_arr = strain_df["Step"].to_numpy().astype(np.int64)
+        counts_arr = strain_df["count"].to_numpy(dtype=float)
+        bic_arr = bits_in_common[strains_arr]
+        step_idx_arr = np.searchsorted(unique_steps, steps_arr)
+
+        density = np.zeros((N_SITES + 1, T), dtype=float)
+        np.add.at(density, (bic_arr, step_idx_arr), counts_arr)
+
+        # Normalize each column so values represent the proportion of
+        # *circulating* strains rather than the host-population
+        # fraction. Steps with no infections leave the column at zero.
+        col_totals = density.sum(axis=0, keepdims=True)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            density = np.where(col_totals > 0, density / col_totals, 0.0)
+
+        base_cmap = plt.get_cmap(cmap)
+        trunc_cmap = mcolors.LinearSegmentedColormap.from_list(
+            f"{cmap}_trunc",
+            base_cmap(np.linspace(0.2, 1.0, 256)),
+        )
+        trunc_cmap.set_bad("white")
+        masked_density = np.ma.masked_equal(density, 0.0)
+
+        with tp.teed(
+            plt.subplots,
+            figsize=(8, 1.5 + 0.4 * (N_SITES + 1)),
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, ax):
+            # origin="lower" places density[0, :] (bits_in_common = 0,
+            # complement of end-state strain) at the bottom and
+            # density[N_SITES, :] (identical with end-state) at the top.
+            im = ax.imshow(
+                masked_density,
+                origin="lower",
+                aspect="auto",
+                cmap=trunc_cmap,
+                extent=[
+                    float(unique_steps.min()) - 0.5,
+                    float(unique_steps.max()) + 0.5,
+                    -0.5,
+                    N_SITES + 0.5,
+                ],
+                interpolation="nearest",
+            )
+            ax.set_yticks(np.arange(N_SITES + 1))
+            ax.set_xlabel("Time")
+            ax.set_ylabel(
+                "bits in common with\nend-state strain "
+                f"{end_strain:0{N_SITES}b}"
+            )
+            cbar = fig.colorbar(im, ax=ax, pad=0.02)
+            cbar.set_label("Fraction of circulating strains")
+            sns.despine(ax=ax)
+
+    return (make_density_heatmap_plot,)
+
+
+@app.cell
+def def_make_hamming_weight_plot(pathlib, plt, sns, tp):
+    def make_hamming_weight_plot(
+        N_SITES: int,
+        hw_df,
+        palette: str = "rocket_r",
+        teeplot_outattrs: dict = {},
+    ) -> None:
+        """Stacked time series of the number of cases (currently
+        infected hosts) at each Hamming weight. A circulating strain's
+        Hamming weight is the number of mutations separating it from the
+        founder (all-zero wildtype) strain, so weight 0 is the founder
+        itself and higher weights are progressively more diverged.
+        Counts are read from the `n_cases` column logged by
+        `simulate()`; the bands stack to the total circulating case
+        load at each step.
+        """
+        pivot = (
+            hw_df.pivot_table(
+                index="hw",
+                columns="Step",
+                values="n_cases",
+                aggfunc="sum",
+                fill_value=0,
+            )
+            .reindex(range(N_SITES + 1), fill_value=0)
+            .sort_index(axis=1)
+        )
+        steps = pivot.columns.to_numpy(dtype=float)
+        cases = pivot.to_numpy(dtype=float)
+
+        colors = sns.color_palette(palette, N_SITES + 1)
+        labels = [f"HW {w}" for w in range(N_SITES + 1)]
+
+        with tp.teed(
+            plt.subplots,
+            figsize=(8, 5),
+            teeplot_outattrs=teeplot_outattrs,
+            teeplot_show=True,
+            teeplot_subdir=pathlib.Path(__file__).stem,
+        ) as (fig, ax):
+            ax.stackplot(steps, cases, labels=labels, colors=colors)
+            ax.set_xlabel("Time")
+            ax.set_ylabel("Number of cases")
+            ax.set_ylim(bottom=0.0)
+            if len(steps):
+                ax.set_xlim(float(steps.min()), float(steps.max()))
+            ax.legend(
+                title="Hamming weight",
+                loc="center left",
+                bbox_to_anchor=(1.02, 0.5),
+                frameon=False,
+                handletextpad=0.4,
+                ncol=1 if N_SITES <= 10 else 2,
+                fontsize=8,
+            )
+            sns.despine(ax=ax)
+
+    return (make_hamming_weight_plot,)
+
+
+@app.cell(hide_code=True)
+def delimit_run(mo):
+    mo.md(
+        """
+    ## Founder Replicate Run
+
+    Run a single replicate for the command-line `seed` / `N_SITES`
+    condition, stamp the simulation parameters and a `replicate_uid`
+    onto every output dataframe, write the dataframes to parquet, and
+    render the Hamming-weight case-count stackplot together with the
+    inherited strain/allele/R/phylogeny figures.
+    """
+    )
+    return
+
+
+@app.cell
+def run_founder(
+    ENGINE,
+    N_SITES,
+    N_STEPS,
+    POP_SIZE,
+    POW,
+    SEED,
+    SKIP_PLOTTING,
+    make_allele_curves_plot,
+    make_density_heatmap_plot,
+    make_hamming_weight_plot,
+    make_phylogeny_plot,
+    make_r_curves_plot,
+    make_strain_curves_plot,
+    make_strain_graph_plot,
+    make_strain_summary_plot,
+    pathlib,
+    reconstruct_phylogeny,
+    simulate,
+    uuid,
+):
+    # Fixed epidemiological parameters (not exposed on the command
+    # line); these mirror the settings used by the parent sweep
+    # notebook 2026-05-06-allele-abm-r-per-strain.py.
+    MUTATION_RATE = 1e-5
+    CONTACT_RATE = 0.35
+    RECOVERY_RATE = 0.1
+    WANING_RATE = 0.01
+    IMMUNE_STRENGTH = 0.7
+    SEED_COUNT = 2
+    IMMUNITY_FLOOR = 0.05
+    IMMUNITY_CEILING = 1.0
+
+    n_strains = 1 << N_SITES
+    # Per-strain figures draw one line/node per strain (or build an
+    # n_strains x n_strains adjacency matrix); gate them off above 16
+    # strains so the aggregate figures (Hamming weight, density
+    # heatmap) still render at large N_SITES.
+    do_per_strain_plots = n_strains <= 16
+
+    # Replicate UUID (standard-library uuid) --- uniquely identifies
+    # the rows produced by this run across invocations and seeds.
+    replicate_uid = uuid.uuid4().hex
+    print(
+        f"=== founder run: seed={SEED} N_SITES={N_SITES} "
+        f"pop_size={POP_SIZE} n_steps={N_STEPS} engine={ENGINE} "
+        f"uid={replicate_uid} ===",
+    )
+
+    traj_df, hw_df, strain_df, records_df = simulate(
+        MUTATION_RATE=MUTATION_RATE,
+        N_SITES=N_SITES,
+        N_STEPS=N_STEPS,
+        POP_SIZE=POP_SIZE,
+        CONTACT_RATE=CONTACT_RATE,
+        RECOVERY_RATE=RECOVERY_RATE,
+        WANING_RATE=WANING_RATE,
+        IMMUNE_STRENGTH=IMMUNE_STRENGTH,
+        SEED_COUNT=SEED_COUNT,
+        IMMUNITY_FLOOR=IMMUNITY_FLOOR,
+        IMMUNITY_CEILING=IMMUNITY_CEILING,
+        seed=SEED,
+        track_phylogeny=True,
+        N_SAMPLE=200,
+        pow=POW,
+    )
+    print(f"  snapshot rows: {len(records_df)}")
+
+    # Simulation parameters recorded as constant-valued columns so each
+    # output dataframe is self-describing --- e.g. every row carries the
+    # population size it was produced under --- plus the replicate UUID.
+    params = {
+        "replicate_uid": replicate_uid,
+        "seed": SEED,
+        "n_sites": N_SITES,
+        "pop_size": POP_SIZE,
+        "n_steps": N_STEPS,
+        "engine": ENGINE,
+        "pow": POW,
+        "mutation_rate": MUTATION_RATE,
+        "contact_rate": CONTACT_RATE,
+        "recovery_rate": RECOVERY_RATE,
+        "waning_rate": WANING_RATE,
+        "immune_strength": IMMUNE_STRENGTH,
+        "seed_count": SEED_COUNT,
+        "immunity_floor": IMMUNITY_FLOOR,
+        "immunity_ceiling": IMMUNITY_CEILING,
+    }
+
+    nbname = pathlib.Path(__file__).stem
+    out_dir = pathlib.Path("outdata") / nbname
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    def _save(kind, df):
+        rep_dir = out_dir / kind / replicate_uid
+        rep_dir.mkdir(parents=True, exist_ok=True)
+        rep_path = rep_dir / f"a={kind}+what={nbname}+ext=.pqt"
+        df.to_parquet(rep_path, index=False)
+        print(f"  wrote {kind} parquet ({len(df)} rows): {rep_path}")
+
+    _save("traj", traj_df.assign(**params))
+    _save("hw", hw_df.assign(**params))
+    _save("strain", strain_df.assign(**params))
+    _save("records", records_df.assign(**params))
+
+    teeplot_base = {
+        "n_sites": N_SITES,
+        "n_steps": int(traj_df["Step"].max()) + 1,
+        "replicate": SEED,
+        "pow": POW,
+    }
+
+    if SKIP_PLOTTING:
+        print("  (SKIP_PLOTTING=True --- skipping all figures)")
+    else:
+        for _palette in "rocket_r", "viridis", "mako":
+            make_hamming_weight_plot(
+                N_SITES,
+                hw_df,
+                palette=_palette,
+                teeplot_outattrs={
+                    **teeplot_base,
+                    "a": "hamming-weight",
+                    "palette": _palette,
+                },
+            )
+        for _palette in "husl", "hls", "Set2":
+            if do_per_strain_plots:
+                make_strain_curves_plot(
+                    N_SITES,
+                    traj_df,
+                    strain_df,
+                    palette=_palette,
+                    teeplot_outattrs={
+                        **teeplot_base,
+                        "a": "strain-curves",
+                        "palette": _palette,
+                    },
+                )
+            make_allele_curves_plot(
+                N_SITES,
+                traj_df,
+                strain_df,
+                palette=_palette,
+                teeplot_outattrs={
+                    **teeplot_base,
+                    "a": "allele-curves",
+                    "palette": _palette,
+                },
+            )
+            if do_per_strain_plots:
+                make_r_curves_plot(
+                    N_SITES,
+                    strain_df,
+                    RECOVERY_RATE=RECOVERY_RATE,
+                    palette=_palette,
+                    teeplot_outattrs={
+                        **teeplot_base,
+                        "a": "r-curves",
+                        "palette": _palette,
+                    },
+                )
+                make_strain_summary_plot(
+                    N_SITES,
+                    traj_df,
+                    strain_df,
+                    RECOVERY_RATE=RECOVERY_RATE,
+                    palette=_palette,
+                    teeplot_outattrs={
+                        **teeplot_base,
+                        "a": "strain-summary",
+                        "palette": _palette,
+                    },
+                )
+        for _cmap in "rocket", "viridis", "magma":
+            make_density_heatmap_plot(
+                N_SITES,
+                strain_df,
+                cmap=_cmap,
+                teeplot_outattrs={
+                    **teeplot_base,
+                    "a": "density-heatmap",
+                    "cmap": _cmap,
+                },
+            )
+
+    if len(records_df) == 0:
+        print("  (no infected hosts --- skipping phylogeny reconstruction)")
+    else:
+        print(f"  extant rows: {int(records_df['extant'].sum())}")
+        if not SKIP_PLOTTING and not do_per_strain_plots:
+            print("  (n_strains too large --- skipping strain graph)")
+        elif not SKIP_PLOTTING:
+            for _palette in "rocket_r", "tab20", "tab10":
+                make_strain_graph_plot(
+                    N_SITES,
+                    records_df,
+                    max_n=4,
+                    palette=_palette,
+                    teeplot_outattrs={
+                        **teeplot_base,
+                        "a": "strain-graph",
+                        "palette": _palette,
+                    },
+                )
+
+        phylogeny_df = reconstruct_phylogeny(records_df)
+        print(f"  reconstructed: {len(phylogeny_df)} nodes")
+        print(f"  extant tips: {int(phylogeny_df['extant'].sum())}")
+        _save("phylo", phylogeny_df.assign(**params))
+
+        if not SKIP_PLOTTING:
+            for _palette in "rocket_r", "tab20", "tab10":
+                make_phylogeny_plot(
+                    N_SITES,
+                    traj_df,
+                    hw_df,
+                    phylogeny_df,
+                    seed=SEED,
+                    palette=_palette,
+                    teeplot_outattrs={
+                        **teeplot_base,
+                        "method": "hstrat-surface",
+                        "palette": _palette,
+                    },
+                )
+
+    print(f"founder run complete: uid={replicate_uid}")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/bindle/2026-05-20-founder.py
+++ b/bindle/2026-05-20-founder.py
@@ -133,7 +133,8 @@ def configure_backend(ENGINE, cp, np):
 
 @app.cell(hide_code=True)
 def delimit_simulation(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Simulation Implementation
 
     This is a **founder** notebook: it runs a *single replicate* of the
@@ -239,7 +240,8 @@ def delimit_simulation(mo):
 
     The vectorized deposit pattern is adapted from
     https://github.com/mmore500/hstrat-synthesis (see `pylib/track_ca.py`).
-    """)
+    """
+    )
     return
 
 
@@ -845,7 +847,8 @@ def def_simulate(
 
 @app.cell(hide_code=True)
 def delimit_reconstruct(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Surface-Annotation Reconstruction
 
     Given the snapshot records emitted by `simulate(..., track_phylogeny=
@@ -853,7 +856,8 @@ def delimit_reconstruct(mo):
     `hstrat.dataframe.surface_postprocess_trie` to estimate the phylogenetic
     tree. We use `AssignOriginTimeNodeRankTriePostprocessor(t0="dstream_S")`
     so that origin times line up with simulation step numbers.
-    """)
+    """
+    )
     return
 
 
@@ -886,12 +890,14 @@ def def_reconstruct_phylogeny(gc, hstrat, pd, pl):
 
 @app.cell(hide_code=True)
 def delimit_phylogeny(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Surface-Reconstructed Phylogeny
 
     Sweep `N_SITES` over a few values and render the surface-reconstructed
     phylogeny next to the absolute-prevalence and Hamming-weight stackplots.
-    """)
+    """
+    )
     return
 
 
@@ -1876,7 +1882,8 @@ def def_make_hamming_weight_plot(pathlib, plt, sns, tp):
 
 @app.cell(hide_code=True)
 def delimit_run(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Founder Replicate Run
 
     Run a single replicate for the command-line `seed` / `N_SITES`
@@ -1884,7 +1891,8 @@ def delimit_run(mo):
     onto every output dataframe, write the dataframes to parquet, and
     render the Hamming-weight case-count stackplot together with the
     inherited strain/allele/R/phylogeny figures.
-    """)
+    """
+    )
     return
 
 

--- a/bindle/2026-05-20-founder.py
+++ b/bindle/2026-05-20-founder.py
@@ -133,8 +133,7 @@ def configure_backend(ENGINE, cp, np):
 
 @app.cell(hide_code=True)
 def delimit_simulation(mo):
-    mo.md(
-        """
+    mo.md("""
     ## Simulation Implementation
 
     This is a **founder** notebook: it runs a *single replicate* of the
@@ -166,11 +165,21 @@ def delimit_simulation(mo):
     strains is logged **as a raw case count** --- the number of
     currently-infected hosts at each Hamming weight --- in the
     `n_cases` column of the `hw` dataframe, alongside the inherited
-    population-fraction `count` column. Every output dataframe is also
-    stamped with the simulation parameters as constant-valued columns
-    and a `replicate_uid` generated with the standard-library `uuid`
-    module, so rows from a run are self-describing and uniquely
-    identifiable.
+    population-fraction `count` column. The `strain` dataframe likewise
+    gets a per-genome raw case count `n_cases` (number of currently-
+    infected hosts carrying each genome) plus `n_new_infections` (new
+    infections caused by each genome this step, pre-mutation). Every
+    output dataframe is also stamped with the simulation parameters as
+    constant-valued columns and a `replicate_uid` generated with the
+    standard-library `uuid` module, so rows from a run are self-
+    describing and uniquely identifiable.
+
+    `update_recoveries()` is patched to **prevent extinction**: if a
+    step's recovery roll would clear the last remaining infection, one
+    of the would-be-recovered hosts is exempted so the run never drops
+    to zero circulating cases. The rescued host continues as an
+    ordinary infected host into the next step without gaining immunity
+    against its current strain.
 
     When the strain count `2 ** N_SITES` exceeds 16, the per-strain
     figures (strain curves, R-curves, strain summary, strain graph) are
@@ -230,8 +239,7 @@ def delimit_simulation(mo):
 
     The vectorized deposit pattern is adapted from
     https://github.com/mmore500/hstrat-synthesis (see `pylib/track_ca.py`).
-    """
-    )
+    """)
     return
 
 
@@ -431,6 +439,22 @@ def def_simulate(
                 POP_SIZE
             ) > 1 - RECOVERY_RATE
 
+            # Prevent extinction: if every currently-infected host would
+            # recover this step, exempt one of the would-be-recovered
+            # hosts so at least one infection always remains. The
+            # rescued host's `recovered_mask` entry is cleared, so its
+            # genome's per-site immunities aren't bumped to 1.0 and its
+            # `host_statuses` stays positive --- it continues as an
+            # ordinary infected host into the next step.
+            infected_pre = host_statuses >= 1
+            if bool(xp.any(infected_pre)) and not bool(
+                xp.any(infected_pre & ~recovered_mask)
+            ):
+                rescue_idx = int(
+                    xp.where(infected_pre & recovered_mask)[0][0],
+                )
+                recovered_mask[rescue_idx] = False
+
             pathogen_bits = (
                 pathogen_genomes[:, None] >> xp.arange(N_SITES, dtype=xp.uint8)
             ) & 1
@@ -609,6 +633,11 @@ def def_simulate(
             # fraction.
             hw_case_counts: List[int] = [0] * (N_SITES + 1)
             strain_prevalences: List[float] = [0.0] * n_strains
+            # Raw per-genome infection counts (currently-infected hosts
+            # carrying each strain), recorded alongside the population-
+            # fraction `count` so the strain dataframe carries the
+            # absolute per-genome case load.
+            strain_case_counts: List[int] = [0] * n_strains
 
             if xp.any(inf_mask):
                 infected_bits = (
@@ -625,20 +654,26 @@ def def_simulate(
                 strain_counts_arr = xp.bincount(
                     strain_per_host, minlength=n_strains
                 )
+                _strain_counts_list = strain_counts_arr.tolist()
+                strain_case_counts = [int(c) for c in _strain_counts_list]
                 strain_prevalences = [
-                    float(c) / POP_SIZE for c in strain_counts_arr.tolist()
+                    float(c) / POP_SIZE for c in _strain_counts_list
                 ]
 
-            # Per-strain new infections this step (population fraction).
+            # Per-strain new infections this step (raw count of newly-
+            # infected hosts and the equivalent population fraction).
             # Captured pre-mutation in update_simulation so the strain
             # label is the strain that actually transmitted.
+            new_strain_n_cases: List[int] = [0] * n_strains
             if new_strain_genomes.size > 0:
                 new_strain_counts_arr = xp.bincount(
                     new_strain_genomes.astype(xp.int64),
                     minlength=n_strains,
                 )
+                _new_strain_list = new_strain_counts_arr.tolist()
+                new_strain_n_cases = [int(c) for c in _new_strain_list]
                 new_strain_counts = [
-                    float(c) / POP_SIZE for c in new_strain_counts_arr.tolist()
+                    float(c) / POP_SIZE for c in _new_strain_list
                 ]
             else:
                 new_strain_counts = [0.0] * n_strains
@@ -695,7 +730,9 @@ def def_simulate(
                         "Seed": seed,
                         "strain": s,
                         "count": count,
+                        "n_cases": strain_case_counts[s],
                         "new_infections": new_strain_counts[s],
+                        "n_new_infections": new_strain_n_cases[s],
                         "expected_R": expected_R_list[s],
                     }
                 )
@@ -808,8 +845,7 @@ def def_simulate(
 
 @app.cell(hide_code=True)
 def delimit_reconstruct(mo):
-    mo.md(
-        """
+    mo.md("""
     ## Surface-Annotation Reconstruction
 
     Given the snapshot records emitted by `simulate(..., track_phylogeny=
@@ -817,8 +853,7 @@ def delimit_reconstruct(mo):
     `hstrat.dataframe.surface_postprocess_trie` to estimate the phylogenetic
     tree. We use `AssignOriginTimeNodeRankTriePostprocessor(t0="dstream_S")`
     so that origin times line up with simulation step numbers.
-    """
-    )
+    """)
     return
 
 
@@ -851,14 +886,12 @@ def def_reconstruct_phylogeny(gc, hstrat, pd, pl):
 
 @app.cell(hide_code=True)
 def delimit_phylogeny(mo):
-    mo.md(
-        """
+    mo.md("""
     ## Surface-Reconstructed Phylogeny
 
     Sweep `N_SITES` over a few values and render the surface-reconstructed
     phylogeny next to the absolute-prevalence and Hamming-weight stackplots.
-    """
-    )
+    """)
     return
 
 
@@ -1843,8 +1876,7 @@ def def_make_hamming_weight_plot(pathlib, plt, sns, tp):
 
 @app.cell(hide_code=True)
 def delimit_run(mo):
-    mo.md(
-        """
+    mo.md("""
     ## Founder Replicate Run
 
     Run a single replicate for the command-line `seed` / `N_SITES`
@@ -1852,8 +1884,7 @@ def delimit_run(mo):
     onto every output dataframe, write the dataframes to parquet, and
     render the Hamming-weight case-count stackplot together with the
     inherited strain/allele/R/phylogeny figures.
-    """
-    )
+    """)
     return
 
 

--- a/bindle/2026-05-27-founder-top2-convergence.py
+++ b/bindle/2026-05-27-founder-top2-convergence.py
@@ -1,0 +1,275 @@
+import marimo
+
+__generated_with = "0.23.2"
+app = marimo.App(width="full")
+
+
+@app.cell
+def import_std():
+    import pathlib
+
+    return (pathlib,)
+
+
+@app.cell
+def import_pkg():
+    import marimo as mo
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+    import requests
+    import seaborn as sns
+    from teeplot import teeplot as tp
+    from watermark import watermark
+
+    return mo, np, pd, plt, requests, sns, tp, watermark
+
+
+@app.cell(hide_code=True)
+def do_watermark(mo, watermark):
+    mo.md(
+        f"""
+    ```Text
+    {watermark(
+        current_date=True,
+        iso8601=True,
+        machine=True,
+        updated=True,
+        python=True,
+        iversions=True,
+        globals_=globals(),
+    )}
+    ```
+    """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def delimit_data(mo):
+    mo.md(
+        """
+    ## Data
+
+    Load the per-replicate Hamming-weight time series produced by the
+    founder-sweep slurm job (`slurm/2026-05-20/2026-05-20-founder.sh`,
+    notebook `bindle/2026-05-20-founder.py`), cached as a parquet on
+    OSF. The sweep covers four `N_SITES` conditions
+    (`2, 3, 4, 5`) at 20 replicates each, 5000 steps per replicate,
+    POP_SIZE=100_000, on CPU (engine=numpy). The dataframe has one
+    row per `(replicate_uid, Step, hw)` with the per-step number of
+    cases (`n_cases`) at each Hamming weight, alongside the
+    simulation parameters as constant-valued columns.
+
+    The OSF slug is downloaded with `requests` and cached at
+    `/tmp/<slug>` so re-runs hit the local copy.
+    """
+    )
+    return
+
+
+@app.cell
+def configure_args(mo):
+    # CLI args. Defaults pull the founder-sweep hw parquet that
+    # backs this notebook.
+    _args = mo.cli_args()
+    OSF_SLUG = str(_args.get("osf-slug") or "xzusj")
+    OSF_URL = str(
+        _args.get("osf-url") or f"https://osf.io/{OSF_SLUG}/download",
+    )
+    print(f"args: OSF_SLUG={OSF_SLUG} OSF_URL={OSF_URL}")
+    return OSF_SLUG, OSF_URL
+
+
+@app.cell
+def download_data(OSF_SLUG, OSF_URL, pathlib, pd, requests):
+    cache_path = pathlib.Path("/tmp") / OSF_SLUG
+    if not cache_path.exists():
+        print(f"downloading {OSF_URL} -> {cache_path}")
+        resp = requests.get(OSF_URL, allow_redirects=True, timeout=120)
+        resp.raise_for_status()
+        cache_path.write_bytes(resp.content)
+    else:
+        print(f"reusing cached {cache_path}")
+    print(f"size: {cache_path.stat().st_size} bytes")
+
+    hw_df = pd.read_parquet(cache_path)
+    print(f"loaded hw dataframe: {hw_df.shape}")
+    print(
+        "n_sites x replicate counts:\n"
+        + str(hw_df.groupby("n_sites")["replicate_uid"].nunique()),
+    )
+    return (hw_df,)
+
+
+@app.cell(hide_code=True)
+def delimit_analysis(mo):
+    mo.md(
+        """
+    ## Top-2 Convergence Hamming Weights
+
+    For each replicate, locate the run's last simulation step and
+    identify the **top two Hamming-weight bins** by case count
+    (`n_cases`) at that step. The Hamming-weight bin is used as a
+    coarse strain identifier --- with only the aggregated `hw`
+    dataframe in hand, each bin stands in for the set of genomes
+    sharing a given mutational distance from the founder
+    (all-zero wildtype) strain.
+
+    We then tabulate, separately for each `N_SITES` condition, the
+    **fraction of replicates** whose end-state top-two pair falls at
+    each `(hw_top1, hw_top2)` combination. Convergence to a single
+    Hamming weight shows up as mass on the `hw_top1 == hw_top2`
+    diagonal; divergent convergence to two distinct evolutionary
+    clusters shows up as off-diagonal mass.
+    """
+    )
+    return
+
+
+@app.cell
+def compute_top2(hw_df, pd):
+    # Use the final step of each replicate (n_steps is constant within a
+    # replicate, but compute per-replicate to be safe).
+    last_steps = hw_df.groupby("replicate_uid")["Step"].transform("max")
+    last = hw_df[hw_df["Step"] == last_steps].copy()
+
+    def _top2(group):
+        ranked = group.sort_values("n_cases", ascending=False)
+        ranked = ranked[ranked["n_cases"] > 0]
+        if len(ranked) == 0:
+            return None
+        top1_hw = int(ranked["hw"].iloc[0])
+        # If only one Hamming-weight bin is occupied at end (rare given
+        # extinction prevention guarantees at least one circulating
+        # case, but the founder allele can be the sole survivor), fall
+        # back to top1 so the pair stays well-defined.
+        top2_hw = int(ranked["hw"].iloc[1]) if len(ranked) >= 2 else top1_hw
+        return top1_hw, top2_hw
+
+    rows = []
+    for (_uid, _n_sites), _sub in last.groupby(
+        ["replicate_uid", "n_sites"],
+    ):
+        _pair = _top2(_sub)
+        if _pair is None:
+            continue
+        rows.append(
+            {
+                "replicate_uid": _uid,
+                "n_sites": int(_n_sites),
+                "hw_top1": _pair[0],
+                "hw_top2": _pair[1],
+            },
+        )
+
+    top2_df = pd.DataFrame(rows)
+    print(f"top-2 frame: {top2_df.shape}")
+    print(
+        "replicates per n_sites:\n" + str(top2_df.groupby("n_sites").size()),
+    )
+    return (top2_df,)
+
+
+@app.cell
+def compute_fractions(top2_df):
+    # Fraction of replicates per (n_sites, hw_top1, hw_top2) cell.
+    counts = (
+        top2_df.groupby(["n_sites", "hw_top1", "hw_top2"])
+        .size()
+        .rename("n_reps")
+        .reset_index()
+    )
+    totals = top2_df.groupby("n_sites").size().rename("n_total").reset_index()
+    frac_df = counts.merge(totals, on="n_sites")
+    frac_df["fraction"] = frac_df["n_reps"] / frac_df["n_total"]
+    print(frac_df.to_string(index=False))
+    return (frac_df,)
+
+
+@app.cell(hide_code=True)
+def delimit_plot(mo):
+    mo.md(
+        """
+    ## Fraction-of-Runs Heatmap
+
+    One panel per `N_SITES` condition. Axes are the top-two Hamming
+    weights at the final step (`hw_top1` = most-populous bin,
+    `hw_top2` = second-most). Cell color encodes the fraction of
+    replicates (out of 20) whose end state lands in that pair; cells
+    with no replicates are masked white. The fraction-as-text overlay
+    makes it easy to read off counts directly.
+    """
+    )
+    return
+
+
+@app.cell
+def plot_fraction_heatmap(frac_df, np, pathlib, plt, sns, tp):
+    n_sites_vals = sorted(frac_df["n_sites"].unique().tolist())
+    n_panels = len(n_sites_vals)
+
+    with tp.teed(
+        plt.subplots,
+        nrows=1,
+        ncols=n_panels,
+        figsize=(3.6 * n_panels, 3.6),
+        squeeze=False,
+        teeplot_outattrs={"a": "top2-hw-fraction"},
+        teeplot_show=True,
+        teeplot_subdir=pathlib.Path(__file__).stem,
+    ) as (fig, axes):
+        axes = axes[0]
+        for _ax, _ns in zip(axes, n_sites_vals):
+            _sub = frac_df[frac_df["n_sites"] == _ns]
+            _hw_max = int(_ns)
+            grid = np.full((_hw_max + 1, _hw_max + 1), np.nan)
+            for _, _row in _sub.iterrows():
+                grid[int(_row["hw_top2"]), int(_row["hw_top1"])] = float(
+                    _row["fraction"],
+                )
+            _masked = np.ma.masked_invalid(grid)
+            _cmap = plt.get_cmap("rocket_r").copy()
+            _cmap.set_bad("white")
+            _im = _ax.imshow(
+                _masked,
+                origin="lower",
+                cmap=_cmap,
+                vmin=0.0,
+                vmax=1.0,
+                aspect="equal",
+                interpolation="nearest",
+            )
+            for _i in range(_hw_max + 1):
+                for _j in range(_hw_max + 1):
+                    if not np.ma.is_masked(_masked[_i, _j]):
+                        _ax.text(
+                            _j,
+                            _i,
+                            f"{_masked[_i, _j]:.2f}",
+                            ha="center",
+                            va="center",
+                            fontsize=8,
+                            color=(
+                                "white" if _masked[_i, _j] > 0.5 else "black"
+                            ),
+                        )
+            _ax.set_xticks(range(_hw_max + 1))
+            _ax.set_yticks(range(_hw_max + 1))
+            _ax.set_xlabel("hw_top1 (most-populous bin)")
+            _ax.set_ylabel("hw_top2 (second-most)")
+            _ax.set_title(f"N_SITES = {_ns}")
+            sns.despine(ax=_ax, left=True, bottom=True)
+        cbar = fig.colorbar(
+            _im,
+            ax=axes,
+            pad=0.02,
+            shrink=0.85,
+            label="fraction of replicates",
+        )
+        _ = cbar
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/bindle/2026-05-27-founder-top2-convergence.py
+++ b/bindle/2026-05-27-founder-top2-convergence.py
@@ -569,7 +569,7 @@ def delimit_appearance(mo):
 
 
 @app.cell
-def compute_first_appearance(hw_df, top2_df):
+def compute_first_appearance(hw_df, np, top2_df):
     # Earliest step at which the all-ones strain (hw == n_sites) has
     # any circulating cases, per replicate.
     _max_hw_mask = (hw_df["hw"] == hw_df["n_sites"]) & (hw_df["n_cases"] > 0)
@@ -598,6 +598,12 @@ def compute_first_appearance(hw_df, top2_df):
         .fillna(appearance_df["n_steps"])
         .astype(int)
     )
+    # Outcome metric: hamming offset of the end-state dominant strain
+    # to the nearest extreme (0 = founder, N_SITES = all-ones).
+    appearance_df["hamming_offset"] = np.minimum(
+        appearance_df["hw_top1"],
+        appearance_df["n_sites"] - appearance_df["hw_top1"],
+    )
 
     print(
         "censored (never appeared) replicates: "
@@ -615,22 +621,23 @@ def plot_appearance_vs_outcome(appearance_df, pathlib, sns, tp):
         sns.lmplot,
         data=appearance_df,
         x="first_max_hw_step",
-        y="hw_top1",
+        y="hamming_offset",
         col="n_sites",
         col_wrap=2,
         height=3.0,
         aspect=1.2,
         x_jitter=20.0,
-        y_jitter=0.15,
+        y_jitter=0.1,
         scatter_kws={"alpha": 0.65, "s": 36},
         line_kws={"color": "black"},
-        teeplot_outattrs={"a": "first-max-hw-vs-hw-top1"},
+        facet_kws={"sharex": False, "sharey": False},
+        teeplot_outattrs={"a": "first-max-hw-vs-hamming-offset"},
         teeplot_show=True,
         teeplot_subdir=pathlib.Path(__file__).stem,
     ) as _g:
         _g.set_axis_labels(
             "first step max-hw strain appears\n(censored at N_STEPS)",
-            "hw_top1 (end-state)",
+            "hamming_offset = min(hw_top1, N_SITES - hw_top1)",
         )
         _g.set_titles("N_SITES = {col_name}")
         for _ax in _g.axes.flat:
@@ -644,7 +651,7 @@ def first_appearance_stats(appearance_df, mo, pd, sps):
     for _ns in sorted(appearance_df["n_sites"].unique().tolist()):
         _sub = appearance_df[appearance_df["n_sites"] == _ns]
         _x = _sub["first_max_hw_step"].to_numpy()
-        _y = _sub["hw_top1"].to_numpy()
+        _y = _sub["hamming_offset"].to_numpy()
         _rho, _pval = sps.spearmanr(_x, _y)
         _rows.append(
             {
@@ -657,7 +664,7 @@ def first_appearance_stats(appearance_df, mo, pd, sps):
         )
     _rho_all, _pval_all = sps.spearmanr(
         appearance_df["first_max_hw_step"],
-        appearance_df["hw_top1"],
+        appearance_df["hamming_offset"],
     )
     _rows.append(
         {
@@ -670,7 +677,7 @@ def first_appearance_stats(appearance_df, mo, pd, sps):
     )
     stat_df = pd.DataFrame(_rows)
     print(
-        "Spearman rank correlation: first_max_hw_step vs hw_top1 "
+        "Spearman rank correlation: first_max_hw_step vs hamming_offset "
         "(censored at N_STEPS for non-appearance):",
     )
     print(stat_df.to_string(index=False))

--- a/bindle/2026-05-27-founder-top2-convergence.py
+++ b/bindle/2026-05-27-founder-top2-convergence.py
@@ -47,8 +47,7 @@ def do_watermark(mo, watermark):
 
 @app.cell(hide_code=True)
 def delimit_data(mo):
-    mo.md(
-        """
+    mo.md("""
     ## Data
 
     Load the per-replicate Hamming-weight time series produced by the
@@ -63,8 +62,7 @@ def delimit_data(mo):
 
     The OSF slug is downloaded with `requests` and cached at
     `/tmp/<slug>` so re-runs hit the local copy.
-    """
-    )
+    """)
     return
 
 
@@ -104,8 +102,7 @@ def download_data(OSF_SLUG, OSF_URL, pathlib, pd, requests):
 
 @app.cell(hide_code=True)
 def delimit_analysis(mo):
-    mo.md(
-        """
+    mo.md("""
     ## Top-2 Convergence Hamming Weights
 
     For each replicate, locate the run's last simulation step and
@@ -122,8 +119,7 @@ def delimit_analysis(mo):
     Hamming weight shows up as mass on the `hw_top1 == hw_top2`
     diagonal; divergent convergence to two distinct evolutionary
     clusters shows up as off-diagonal mass.
-    """
-    )
+    """)
     return
 
 
@@ -189,8 +185,7 @@ def compute_fractions(top2_df):
 
 @app.cell(hide_code=True)
 def delimit_plot(mo):
-    mo.md(
-        """
+    mo.md("""
     ## Fraction-of-Runs Heatmap
 
     One panel per `N_SITES` condition. Axes are the top-two Hamming
@@ -199,8 +194,7 @@ def delimit_plot(mo):
     replicates (out of 20) whose end state lands in that pair; cells
     with no replicates are masked white. The fraction-as-text overlay
     makes it easy to read off counts directly.
-    """
-    )
+    """)
     return
 
 
@@ -268,6 +262,134 @@ def plot_fraction_heatmap(frac_df, np, pathlib, plt, sns, tp):
             label="fraction of replicates",
         )
         _ = cbar
+    return
+
+
+@app.cell(hide_code=True)
+def delimit_diff(mo):
+    mo.md("""
+    ## Stacked Histogram by Top-2 Hamming-Weight Difference
+
+    Per-replicate **Hamming-weight gap** between the top-two end-state
+    bins, `hw_diff = |hw_top1 - hw_top2|`. A gap of 0 means the
+    replicate converged to a single dominant Hamming weight (all
+    sub-dominant cases share the same weight); a gap of 1 means the
+    second-most-populous bin sits one mutation away from the dominant
+    one; larger gaps mean the top-two cluster pair spans further
+    apart. We plot the **percent of replicates** (out of 20) at each
+    `hw_diff` value, stacked, per `N_SITES` condition.
+    """)
+    return
+
+
+@app.cell
+def plot_diff_stacked_hist(np, pathlib, plt, sns, top2_df, tp):
+    # Possible Hamming-weight differences range from 0 to max(N_SITES)
+    # since each top bin's hw is in [0, N_SITES]. Set the hue order
+    # explicitly so stack ordering and the legend stay consistent
+    # across N_SITES conditions (smaller diffs at the bottom).
+    _max_n_sites = int(top2_df["n_sites"].max())
+    _hue_order = list(range(_max_n_sites + 1))
+
+    _diff_df = top2_df.assign(
+        hw_diff=(top2_df["hw_top1"] - top2_df["hw_top2"]).abs(),
+    )
+    _totals = _diff_df.groupby("n_sites").size()
+    _pct_wide = (
+        _diff_df.groupby(["n_sites", "hw_diff"]).size().unstack(fill_value=0)
+    )
+    _pct_wide = _pct_wide.div(_totals, axis=0).mul(100.0)
+    _pct_wide = _pct_wide.reindex(columns=_hue_order, fill_value=0.0)
+    print("percent of replicates by (n_sites, hw_diff):")
+    print(_pct_wide.round(1).to_string())
+
+    _palette = sns.color_palette("rocket_r", n_colors=len(_hue_order))
+    _n_conditions = len(_pct_wide.index)
+    _bar_x = np.arange(_n_conditions)
+
+    with tp.teed(
+        plt.subplots,
+        figsize=(1.4 * _n_conditions + 2.0, 4.2),
+        teeplot_outattrs={"a": "top2-hw-diff-stacked-pct"},
+        teeplot_show=True,
+        teeplot_subdir=pathlib.Path(__file__).stem,
+    ) as (_fig, _ax):
+        _bottom = np.zeros(_n_conditions, dtype=float)
+        for _hw_diff, _color in zip(_hue_order, _palette):
+            _heights = _pct_wide[_hw_diff].to_numpy()
+            _ax.bar(
+                _bar_x,
+                _heights,
+                bottom=_bottom,
+                color=_color,
+                label=f"diff = {_hw_diff}",
+                edgecolor="white",
+                linewidth=0.5,
+            )
+            _bottom = _bottom + _heights
+        _ax.set_xticks(_bar_x)
+        _ax.set_xticklabels([str(int(_ns)) for _ns in _pct_wide.index])
+        _ax.set_xlabel("N_SITES")
+        _ax.set_ylabel("% of replicates")
+        _ax.set_ylim(0, 100)
+        # `reverse=True` (matplotlib >= 3.7) shows the largest hw_diff
+        # entry at the top of the legend, matching the stack top-down.
+        _handles, _labels = _ax.get_legend_handles_labels()
+        _ax.legend(
+            _handles[::-1],
+            _labels[::-1],
+            title="|hw_top1 - hw_top2|",
+            loc="center left",
+            bbox_to_anchor=(1.02, 0.5),
+            frameon=False,
+            handletextpad=0.4,
+        )
+        sns.despine(ax=_ax)
+    return
+
+
+@app.cell(hide_code=True)
+def delimit_tables(mo):
+    mo.md("""
+    ## Per-N_SITES Outcome Tables
+
+    One table per `N_SITES` condition listing every observed
+    end-state `(hw_top1, hw_top2)` pair with the percent of
+    replicates that converged there and the Hamming-weight gap
+    `hw_diff`. Rows are sorted by decreasing percent.
+    """)
+    return
+
+
+@app.cell
+def show_tables(frac_df, mo):
+    _pct_df = frac_df.assign(
+        hw_diff=(frac_df["hw_top1"] - frac_df["hw_top2"]).abs(),
+        pct=(frac_df["fraction"] * 100.0).round(2),
+    )[
+        [
+            "n_sites",
+            "hw_top1",
+            "hw_top2",
+            "hw_diff",
+            "n_reps",
+            "n_total",
+            "pct",
+        ]
+    ]
+
+    _panels = []
+    for _ns in sorted(_pct_df["n_sites"].unique().tolist()):
+        _sub = (
+            _pct_df[_pct_df["n_sites"] == _ns]
+            .sort_values("pct", ascending=False)
+            .reset_index(drop=True)
+        )
+        print(f"\nN_SITES = {int(_ns)}")
+        print(_sub.to_string(index=False))
+        _panels.append(mo.md(f"### N_SITES = {int(_ns)}"))
+        _panels.append(mo.ui.table(_sub, selection=None))
+    mo.vstack(_panels)
     return
 
 

--- a/bindle/2026-05-27-founder-top2-convergence.py
+++ b/bindle/2026-05-27-founder-top2-convergence.py
@@ -18,11 +18,12 @@ def import_pkg():
     import numpy as np
     import pandas as pd
     import requests
+    from scipy import stats as sps
     import seaborn as sns
     from teeplot import teeplot as tp
     from watermark import watermark
 
-    return mo, np, pd, plt, requests, sns, tp, watermark
+    return mo, np, pd, plt, requests, sns, sps, tp, watermark
 
 
 @app.cell(hide_code=True)
@@ -540,6 +541,140 @@ def show_offset_tables(mo, np, top2_df):
         _panels.append(mo.md(f"### N_SITES = {int(_ns)}"))
         _panels.append(mo.ui.table(_sub, selection=None))
     mo.vstack(_panels)
+    return
+
+
+@app.cell(hide_code=True)
+def delimit_appearance(mo):
+    mo.md(
+        """
+    ## First Appearance of Max-Hamming-Weight Strain vs. Outcome
+
+    For each replicate, find the **first simulation step** at which
+    any case sits at the maximum Hamming weight `hw == N_SITES` ---
+    the all-ones `1111...` strain, the bitwise complement of the
+    founder. Replicates where the max-hw strain never appears are
+    **censored to the simulation horizon** `N_STEPS` (treated as if
+    it appeared at the very last step), per the analysis spec.
+
+    Plot the resulting first-appearance step against the end-state
+    outcome `hw_top1` (most-populous Hamming weight at the final
+    step) as a per-`N_SITES` `sns.lmplot` with a fitted regression
+    line in each panel, and run a Spearman rank correlation per
+    condition (plus pooled) to test whether earlier emergence of
+    the all-ones strain predicts a higher end-state Hamming weight.
+    """
+    )
+    return
+
+
+@app.cell
+def compute_first_appearance(hw_df, top2_df):
+    # Earliest step at which the all-ones strain (hw == n_sites) has
+    # any circulating cases, per replicate.
+    _max_hw_mask = (hw_df["hw"] == hw_df["n_sites"]) & (hw_df["n_cases"] > 0)
+    _first = (
+        hw_df[_max_hw_mask]
+        .groupby("replicate_uid")["Step"]
+        .min()
+        .rename("first_max_hw_step")
+    )
+
+    _per_rep_meta = (
+        hw_df[["replicate_uid", "n_steps"]]
+        .drop_duplicates()
+        .set_index("replicate_uid")["n_steps"]
+    )
+
+    appearance_df = (
+        top2_df[["replicate_uid", "n_sites", "hw_top1"]]
+        .merge(_first, on="replicate_uid", how="left")
+        .merge(_per_rep_meta, on="replicate_uid", how="left")
+    )
+    # Censor non-appearance to the simulation horizon N_STEPS.
+    appearance_df["censored"] = appearance_df["first_max_hw_step"].isna()
+    appearance_df["first_max_hw_step"] = (
+        appearance_df["first_max_hw_step"]
+        .fillna(appearance_df["n_steps"])
+        .astype(int)
+    )
+
+    print(
+        "censored (never appeared) replicates: "
+        f"{int(appearance_df['censored'].sum())} / {len(appearance_df)}"
+    )
+    print("censored per n_sites:")
+    print(appearance_df.groupby("n_sites")["censored"].sum())
+    print(appearance_df.head().to_string(index=False))
+    return (appearance_df,)
+
+
+@app.cell
+def plot_appearance_vs_outcome(appearance_df, pathlib, sns, tp):
+    with tp.teed(
+        sns.lmplot,
+        data=appearance_df,
+        x="first_max_hw_step",
+        y="hw_top1",
+        col="n_sites",
+        col_wrap=2,
+        height=3.0,
+        aspect=1.2,
+        x_jitter=20.0,
+        y_jitter=0.15,
+        scatter_kws={"alpha": 0.65, "s": 36},
+        line_kws={"color": "black"},
+        teeplot_outattrs={"a": "first-max-hw-vs-hw-top1"},
+        teeplot_show=True,
+        teeplot_subdir=pathlib.Path(__file__).stem,
+    ) as _g:
+        _g.set_axis_labels(
+            "first step max-hw strain appears\n(censored at N_STEPS)",
+            "hw_top1 (end-state)",
+        )
+        _g.set_titles("N_SITES = {col_name}")
+        for _ax in _g.axes.flat:
+            sns.despine(ax=_ax)
+    return
+
+
+@app.cell
+def first_appearance_stats(appearance_df, mo, pd, sps):
+    _rows = []
+    for _ns in sorted(appearance_df["n_sites"].unique().tolist()):
+        _sub = appearance_df[appearance_df["n_sites"] == _ns]
+        _x = _sub["first_max_hw_step"].to_numpy()
+        _y = _sub["hw_top1"].to_numpy()
+        _rho, _pval = sps.spearmanr(_x, _y)
+        _rows.append(
+            {
+                "n_sites": str(int(_ns)),
+                "n": len(_sub),
+                "n_censored": int(_sub["censored"].sum()),
+                "spearman_rho": round(float(_rho), 3),
+                "p_value": float(_pval),
+            },
+        )
+    _rho_all, _pval_all = sps.spearmanr(
+        appearance_df["first_max_hw_step"],
+        appearance_df["hw_top1"],
+    )
+    _rows.append(
+        {
+            "n_sites": "pooled",
+            "n": len(appearance_df),
+            "n_censored": int(appearance_df["censored"].sum()),
+            "spearman_rho": round(float(_rho_all), 3),
+            "p_value": float(_pval_all),
+        },
+    )
+    stat_df = pd.DataFrame(_rows)
+    print(
+        "Spearman rank correlation: first_max_hw_step vs hw_top1 "
+        "(censored at N_STEPS for non-appearance):",
+    )
+    print(stat_df.to_string(index=False))
+    mo.ui.table(stat_df, selection=None)
     return
 
 

--- a/bindle/2026-05-27-founder-top2-convergence.py
+++ b/bindle/2026-05-27-founder-top2-convergence.py
@@ -403,5 +403,145 @@ def show_tables(frac_df, mo):
     return
 
 
+@app.cell(hide_code=True)
+def delimit_offset(mo):
+    mo.md(
+        """
+    ## Stacked Histogram by Top-1 Hamming Offset
+
+    For each replicate, take the **single most-populous** Hamming-
+    weight bin at the final step (`hw_top1`) and report its
+    **hamming offset** `min(hw, N_SITES - hw)`: the smaller of the
+    two distances from `hw` to the nearest "extreme" Hamming weight
+    (`0` = pure founder/wildtype, `N_SITES` = its bitwise
+    complement). An offset of `0` means the dominant strain at end
+    is at one of the two extremes; an offset of `floor(N_SITES /
+    2)` means it sits as far from either extreme as the bit budget
+    allows. Plot the **percent of replicates** at each offset value,
+    stacked per `N_SITES`, with a fixed hue order across panels.
+    """
+    )
+    return
+
+
+@app.cell
+def plot_offset_stacked_hist(np, pathlib, plt, sns, top2_df, tp):
+    _offset_df = top2_df.assign(
+        hamming_offset=np.minimum(
+            top2_df["hw_top1"],
+            top2_df["n_sites"] - top2_df["hw_top1"],
+        ),
+    )
+    _max_n_sites = int(top2_df["n_sites"].max())
+    _max_offset = _max_n_sites // 2
+    _hue_order = list(range(_max_offset + 1))
+
+    _totals = _offset_df.groupby("n_sites").size()
+    _pct_wide = (
+        _offset_df.groupby(["n_sites", "hamming_offset"])
+        .size()
+        .unstack(fill_value=0)
+    )
+    _pct_wide = _pct_wide.div(_totals, axis=0).mul(100.0)
+    _pct_wide = _pct_wide.reindex(columns=_hue_order, fill_value=0.0)
+    print("percent of replicates by (n_sites, hamming_offset):")
+    print(_pct_wide.round(1).to_string())
+
+    _palette = sns.color_palette("mako_r", n_colors=len(_hue_order))
+    _n_conditions = len(_pct_wide.index)
+    _bar_x = np.arange(_n_conditions)
+
+    with tp.teed(
+        plt.subplots,
+        figsize=(1.4 * _n_conditions + 2.0, 4.2),
+        teeplot_outattrs={"a": "top1-hamming-offset-stacked-pct"},
+        teeplot_show=True,
+        teeplot_subdir=pathlib.Path(__file__).stem,
+    ) as (_fig, _ax):
+        _bottom = np.zeros(_n_conditions, dtype=float)
+        for _off, _color in zip(_hue_order, _palette):
+            _heights = _pct_wide[_off].to_numpy()
+            _ax.bar(
+                _bar_x,
+                _heights,
+                bottom=_bottom,
+                color=_color,
+                label=f"offset = {_off}",
+                edgecolor="white",
+                linewidth=0.5,
+            )
+            _bottom = _bottom + _heights
+        _ax.set_xticks(_bar_x)
+        _ax.set_xticklabels([str(int(_ns)) for _ns in _pct_wide.index])
+        _ax.set_xlabel("N_SITES")
+        _ax.set_ylabel("% of replicates")
+        _ax.set_ylim(0, 100)
+        _handles, _labels = _ax.get_legend_handles_labels()
+        _ax.legend(
+            _handles[::-1],
+            _labels[::-1],
+            title="min(hw_top1, N_SITES - hw_top1)",
+            loc="center left",
+            bbox_to_anchor=(1.02, 0.5),
+            frameon=False,
+            handletextpad=0.4,
+        )
+        sns.despine(ax=_ax)
+    return
+
+
+@app.cell(hide_code=True)
+def delimit_offset_tables(mo):
+    mo.md(
+        """
+    ## Per-N_SITES Top-1 Hamming-Offset Tables
+
+    One table per `N_SITES` condition listing each observed value of
+    the top-1 Hamming weight `hw_top1`, its `hamming_offset =
+    min(hw_top1, N_SITES - hw_top1)`, the number of replicates at
+    that value, and the percent of replicates. Sorted by descending
+    percent.
+    """
+    )
+    return
+
+
+@app.cell
+def show_offset_tables(mo, np, top2_df):
+    _offset_full = top2_df.assign(
+        hamming_offset=np.minimum(
+            top2_df["hw_top1"],
+            top2_df["n_sites"] - top2_df["hw_top1"],
+        ),
+    )
+    _counts = (
+        _offset_full.groupby(["n_sites", "hw_top1", "hamming_offset"])
+        .size()
+        .rename("n_reps")
+        .reset_index()
+    )
+    _totals = (
+        _offset_full.groupby("n_sites").size().rename("n_total").reset_index()
+    )
+    _offset_pct = _counts.merge(_totals, on="n_sites")
+    _offset_pct["pct"] = (
+        _offset_pct["n_reps"] / _offset_pct["n_total"] * 100.0
+    ).round(2)
+
+    _panels = []
+    for _ns in sorted(_offset_pct["n_sites"].unique().tolist()):
+        _sub = (
+            _offset_pct[_offset_pct["n_sites"] == _ns]
+            .sort_values("pct", ascending=False)
+            .reset_index(drop=True)
+        )
+        print(f"\nN_SITES = {int(_ns)}")
+        print(_sub.to_string(index=False))
+        _panels.append(mo.md(f"### N_SITES = {int(_ns)}"))
+        _panels.append(mo.ui.table(_sub, selection=None))
+    mo.vstack(_panels)
+    return
+
+
 if __name__ == "__main__":
     app.run()

--- a/bindle/2026-05-27-founder-top2-convergence.py
+++ b/bindle/2026-05-27-founder-top2-convergence.py
@@ -47,7 +47,8 @@ def do_watermark(mo, watermark):
 
 @app.cell(hide_code=True)
 def delimit_data(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Data
 
     Load the per-replicate Hamming-weight time series produced by the
@@ -62,7 +63,8 @@ def delimit_data(mo):
 
     The OSF slug is downloaded with `requests` and cached at
     `/tmp/<slug>` so re-runs hit the local copy.
-    """)
+    """
+    )
     return
 
 
@@ -102,7 +104,8 @@ def download_data(OSF_SLUG, OSF_URL, pathlib, pd, requests):
 
 @app.cell(hide_code=True)
 def delimit_analysis(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Top-2 Convergence Hamming Weights
 
     For each replicate, locate the run's last simulation step and
@@ -119,7 +122,8 @@ def delimit_analysis(mo):
     Hamming weight shows up as mass on the `hw_top1 == hw_top2`
     diagonal; divergent convergence to two distinct evolutionary
     clusters shows up as off-diagonal mass.
-    """)
+    """
+    )
     return
 
 
@@ -185,7 +189,8 @@ def compute_fractions(top2_df):
 
 @app.cell(hide_code=True)
 def delimit_plot(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Fraction-of-Runs Heatmap
 
     One panel per `N_SITES` condition. Axes are the top-two Hamming
@@ -194,7 +199,8 @@ def delimit_plot(mo):
     replicates (out of 20) whose end state lands in that pair; cells
     with no replicates are masked white. The fraction-as-text overlay
     makes it easy to read off counts directly.
-    """)
+    """
+    )
     return
 
 
@@ -267,7 +273,8 @@ def plot_fraction_heatmap(frac_df, np, pathlib, plt, sns, tp):
 
 @app.cell(hide_code=True)
 def delimit_diff(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Stacked Histogram by Top-2 Hamming-Weight Difference
 
     Per-replicate **Hamming-weight gap** between the top-two end-state
@@ -278,7 +285,8 @@ def delimit_diff(mo):
     one; larger gaps mean the top-two cluster pair spans further
     apart. We plot the **percent of replicates** (out of 20) at each
     `hw_diff` value, stacked, per `N_SITES` condition.
-    """)
+    """
+    )
     return
 
 
@@ -350,14 +358,16 @@ def plot_diff_stacked_hist(np, pathlib, plt, sns, top2_df, tp):
 
 @app.cell(hide_code=True)
 def delimit_tables(mo):
-    mo.md("""
+    mo.md(
+        """
     ## Per-N_SITES Outcome Tables
 
     One table per `N_SITES` condition listing every observed
     end-state `(hw_top1, hw_top2)` pair with the percent of
     replicates that converged there and the Hamming-weight gap
     `hw_diff`. Rows are sorted by decreasing percent.
-    """)
+    """
+    )
     return
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -23,6 +23,7 @@ phyloframe==0.8.1
 polars==1.40.1
 pytest==7.2.2
 pyarrow==16.1.0
+requests==2.34.2
 pytest-xdist==3.2.1
 ruff==0.0.260
 scipy==1.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ anytree==2.13.0
     #   hstrat
 astropy==6.1.7
     # via hstrat
-astropy-iers-data==0.2026.4.27.1.3.2
+astropy-iers-data==0.2026.5.25.1.14.13
     # via astropy
 attrs==26.1.0
     # via
@@ -41,7 +41,11 @@ black==22.10.0
     # via -r requirements.in
 bleach==6.3.0
     # via nbconvert
-click==8.3.3
+certifi==2026.5.20
+    # via requests
+charset-normalizer==3.4.7
+    # via requests
+click==8.4.1
     # via
     #   alifedata-phyloinformatics-convert
     #   black
@@ -56,7 +60,7 @@ cycler==0.12.1
     # via matplotlib
 debugpy==1.8.20
     # via ipykernel
-decorator==5.2.1
+decorator==5.3.1
     # via
     #   ipython
     #   retry
@@ -94,7 +98,7 @@ fishersrc==0.1.15
     # via
     #   hstrat
     #   phyloframe
-fonttools==4.62.1
+fonttools==4.63.0
     # via matplotlib
 frozendict==2.4.7
     # via backstrip
@@ -104,14 +108,13 @@ hstrat==1.25.0
     # via -r requirements.in
 hurry-filesize==0.9
     # via nbmetalog
-idna==3.13
+idna==3.16
     # via
     #   anyio
+    #   requests
     #   yarl
 igraph==0.11.9
-    # via
-    #   -r requirements.in
-    #   iplotx
+    # via -r requirements.in
 importlib-metadata==9.0.0
     # via watermark
 iniconfig==2.3.0
@@ -140,7 +143,7 @@ iterpop==0.4.1
     #   hstrat
 itsdangerous==2.2.0
     # via marimo
-jedi==0.19.2
+jedi==0.20.0
     # via
     #   ipython
     #   marimo
@@ -209,11 +212,11 @@ matplotlib==3.10.7
     #   iplotx
     #   seaborn
     #   teeplot
-matplotlib-inline==0.2.1
+matplotlib-inline==0.2.2
     # via
     #   ipykernel
     #   ipython
-mistune==3.2.0
+mistune==3.2.1
     # via nbconvert
 mmh3==5.2.1
     # via hstrat
@@ -235,7 +238,7 @@ mypy-extensions==1.1.0
     #   typing-inspect
 nanto==0.1.1
     # via alifedata-phyloinformatics-convert
-narwhals==2.20.0
+narwhals==2.21.2
     # via marimo
 nb-clean==2.4.0
     # via -r requirements.in
@@ -322,7 +325,7 @@ pandera==0.31.1
     # via hstrat
 pandocfilters==1.5.1
     # via nbconvert
-parso==0.8.6
+parso==0.8.7
     # via jedi
 pathspec==1.1.1
     # via black
@@ -361,7 +364,7 @@ prettytable==3.17.0
     # via hstrat
 prompt-toolkit==3.0.52
     # via ipython
-propcache==0.4.1
+propcache==0.5.2
     # via yarl
 psutil==7.2.2
     # via
@@ -379,9 +382,9 @@ pyarrow==16.1.0
     #   polars
 pycodestyle==2.14.0
     # via autopep8
-pydantic==2.13.3
+pydantic==2.13.4
     # via pandera
-pydantic-core==2.46.3
+pydantic-core==2.46.4
     # via pydantic
 pyerfa==2.0.1.5
     # via astropy
@@ -390,7 +393,7 @@ pygments==2.20.0
     #   ipython
     #   marimo
     #   nbconvert
-pymdown-extensions==10.21.2
+pymdown-extensions==10.21.3
     # via marimo
 pyparsing==3.3.2
     # via matplotlib
@@ -409,7 +412,7 @@ python-slugify==8.0.4
     # via
     #   hstrat
     #   teeplot
-pytz==2026.1.post1
+pytz==2026.2
     # via pandas
 pyyaml==6.0.3
     # via
@@ -426,6 +429,8 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
+requests==2.34.2
+    # via -r requirements.in
 retry==0.9.2
     # via keyname
 rpds-py==0.30.0
@@ -465,9 +470,9 @@ sortedcontainers==2.4.0
     #   alifedata-phyloinformatics-convert
     #   hstrat
     #   phyloframe
-soupsieve==2.8.3
+soupsieve==2.8.4
     # via beautifulsoup4
-starlette==1.0.0
+starlette==1.1.0
     # via marimo
 statsmodels==0.14.6
     # via
@@ -493,7 +498,7 @@ tomli==2.4.1
     #   black
     #   nbqa
     #   pytest
-tomlkit==0.14.0
+tomlkit==0.15.0
     # via marimo
 tornado==6.5.5
     # via
@@ -507,7 +512,7 @@ tqdm==4.64.1
     #   hstrat
     #   joinem
     #   phyloframe
-traitlets==5.14.3
+traitlets==5.15.0
     # via
     #   ipykernel
     #   ipython
@@ -519,7 +524,7 @@ traitlets==5.14.3
     #   nbformat
 treeswift==1.1.45
     # via alifedata-phyloinformatics-convert
-typeguard==4.5.1
+typeguard==4.5.2
     # via pandera
 typing-extensions==4.15.0
     # via
@@ -548,15 +553,17 @@ typing-inspection==0.4.2
     # via pydantic
 tzdata==2026.2
     # via pandas
+urllib3==2.7.0
+    # via requests
 uv==0.4.20
     # via -r requirements.in
-uvicorn==0.46.0
+uvicorn==0.48.0
     # via marimo
 validators==0.35.0
     # via alifedata-phyloinformatics-convert
 watermark==2.4.3
     # via -r requirements.in
-wcwidth==0.6.0
+wcwidth==0.7.0
     # via
     #   prettytable
     #   prompt-toolkit
@@ -568,7 +575,7 @@ websockets==16.0
     # via marimo
 wrapt==1.17.3
     # via deprecated
-yarl==1.23.0
+yarl==1.24.2
     # via alifedata-phyloinformatics-convert
-zipp==3.23.1
+zipp==4.1.0
     # via importlib-metadata

--- a/slurm/2026-05-20/2026-05-20-founder.sh
+++ b/slurm/2026-05-20/2026-05-20-founder.sh
@@ -209,7 +209,7 @@ cat > "${SBATCH_FILE}" << EOF
 #SBATCH --output="/mnt/home/%u/joblog/%j"
 #SBATCH --mail-user=mawni4ah2o@pomail.net
 #SBATCH --mail-type=FAIL,TIME_LIMIT,ARRAY_TASKS
-#SBATCH --account=beacon
+#SBATCH --account=ecode
 #SBATCH --requeue
 #SBATCH --array=0-$((N_TASKS - 1))
 
@@ -281,7 +281,7 @@ cat > "${SBATCH_FILE}" << EOF
 #SBATCH --output="/mnt/home/%u/joblog/%j"
 #SBATCH --mail-user=mawni4ah2o@pomail.net
 #SBATCH --mail-type=ALL
-#SBATCH --account=beacon
+#SBATCH --account=ecode
 #SBATCH --requeue
 
 ${JOB_PREAMBLE}

--- a/slurm/2026-05-20/2026-05-20-founder.sh
+++ b/slurm/2026-05-20/2026-05-20-founder.sh
@@ -1,0 +1,365 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+echo "configuration ==========================================================="
+JOBDATE="$(date '+%Y-%m-%d')"
+echo "JOBDATE ${JOBDATE}"
+
+JOBNAME="$(basename -s .sh "$0")"
+echo "JOBNAME ${JOBNAME}"
+
+JOBPROJECT="$(basename -s .git "$(git remote get-url origin)")"
+echo "JOBPROJECT ${JOBPROJECT}"
+
+NOTEBOOK_NAME="2026-05-20-founder"
+echo "NOTEBOOK_NAME ${NOTEBOOK_NAME}"
+NOTEBOOK_PATH="bindle/${NOTEBOOK_NAME}.py"
+echo "NOTEBOOK_PATH ${NOTEBOOK_PATH}"
+
+# Sweep: 4 N_SITES conditions x 20 replicates = 80 array tasks.
+# Task id i: SITES_LIST[i / 20] for n_sites; (i % 20) + 1 for seed.
+NSITES_LIST=(2 3 4 5)
+N_CONDITIONS=${#NSITES_LIST[@]}
+N_REPLICATES=20
+N_TASKS=$((N_CONDITIONS * N_REPLICATES))
+N_STEPS=5000
+POP_SIZE=100000
+echo "NSITES_LIST=${NSITES_LIST[*]} N_REPLICATES=${N_REPLICATES}"
+echo "N_TASKS=${N_TASKS} N_STEPS=${N_STEPS} POP_SIZE=${POP_SIZE}"
+
+SOURCE_REVISION="$(git rev-parse HEAD)"
+echo "SOURCE_REVISION ${SOURCE_REVISION}"
+SOURCE_REMOTE_URL="$(git config --get remote.origin.url)"
+echo "SOURCE_REMOTE_URL ${SOURCE_REMOTE_URL}"
+
+echo "initialization telemetry ==============================================="
+echo "date $(date)"
+echo "hostname $(hostname)"
+echo "PWD ${PWD}"
+echo "SLURM_JOB_ID ${SLURM_JOB_ID:-nojid}"
+echo "SLURM_ARRAY_TASK_ID ${SLURM_ARRAY_TASK_ID:-notid}"
+module purge || :
+module load Python/3.10.8 || :
+echo "python3.10 $(which python3.10)"
+echo "python3.10 --version $(python3.10 --version)"
+
+echo "setup HOME dirs ========================================================"
+mkdir -p "${HOME}/joblatest"
+mkdir -p "${HOME}/joblog"
+mkdir -p "${HOME}/jobscript"
+if ! [ -e "${HOME}/scratch" ]; then
+    if [ -e "/mnt/scratch/${USER}" ]; then
+        ln -s "/mnt/scratch/${USER}" "${HOME}/scratch" || :
+    else
+        mkdir -p "${HOME}/scratch" || :
+    fi
+fi
+
+echo "setup BATCHDIR =========================================================="
+BATCHDIR="${HOME}/scratch/${JOBPROJECT}/${JOBNAME}/${JOBDATE}"
+if [ -e "${BATCHDIR}" ]; then
+    echo "BATCHDIR ${BATCHDIR} exists, clearing it"
+fi
+rm -rf "${BATCHDIR}"
+mkdir -p "${BATCHDIR}"
+echo "BATCHDIR ${BATCHDIR}"
+
+echo "symlinking latest"
+LATESTDIR="${HOME}/scratch/${JOBPROJECT}/${JOBNAME}/latest"
+echo "${BATCHDIR} > ${LATESTDIR}"
+ln -sfn "${BATCHDIR}" "${LATESTDIR}"
+
+BATCHDIR_JOBLOG="${BATCHDIR}/joblog"
+echo "BATCHDIR_JOBLOG ${BATCHDIR_JOBLOG}"
+mkdir -p "${BATCHDIR_JOBLOG}"
+
+BATCHDIR_JOBRESULT="${BATCHDIR}/jobresult"
+echo "BATCHDIR_JOBRESULT ${BATCHDIR_JOBRESULT}"
+mkdir -p "${BATCHDIR_JOBRESULT}"
+
+BATCHDIR_JOBSCRIPT="${BATCHDIR}/jobscript"
+echo "BATCHDIR_JOBSCRIPT ${BATCHDIR_JOBSCRIPT}"
+mkdir -p "${BATCHDIR_JOBSCRIPT}"
+
+BATCHDIR_JOBSOURCE="${BATCHDIR}/_jobsource"
+echo "BATCHDIR_JOBSOURCE ${BATCHDIR_JOBSOURCE}"
+if [[ $* == *--dirty* ]]; then
+    cp -r "$(git rev-parse --show-toplevel)" "${BATCHDIR_JOBSOURCE}"
+else
+    mkdir -p "${BATCHDIR_JOBSOURCE}"
+    for attempt in {1..5}; do
+        rm -rf "${BATCHDIR_JOBSOURCE}/.git"
+        git -C "${BATCHDIR_JOBSOURCE}" init \
+        && git -C "${BATCHDIR_JOBSOURCE}" remote add origin "${SOURCE_REMOTE_URL}" \
+        && git -C "${BATCHDIR_JOBSOURCE}" fetch origin "${SOURCE_REVISION}" --depth=1 \
+        && git -C "${BATCHDIR_JOBSOURCE}" reset --hard FETCH_HEAD \
+        && break || echo "failed to clone, retrying..."
+        if [ $attempt -eq 5 ]; then
+            echo "failed to clone, failing"
+            exit 1
+        fi
+        sleep 5
+    done
+fi
+
+BATCHDIR_ENV="${BATCHDIR}/_jobenv"
+python3.10 -m venv --system-site-packages "${BATCHDIR_ENV}"
+source "${BATCHDIR_ENV}/bin/activate"
+echo "python3.10 $(which python3.10)"
+echo "python3.10 --version $(python3.10 --version)"
+for attempt in {1..5}; do
+    python3.10 -m pip install --upgrade pip 'setuptools<75' wheel || :
+    python3.10 -m pip install --upgrade uv \
+    && python3.10 -m uv pip install joinem==0.11.1 \
+    && python3.10 -m uv pip install \
+        -r "${BATCHDIR_JOBSOURCE}/requirements.txt" \
+    && break || echo "pip install attempt ${attempt} failed"
+    if [ ${attempt} -eq 5 ]; then
+        echo "pip install failed"
+        exit 1
+    fi
+done
+
+echo "setup dependencies ========================================== \${SECONDS}"
+source "${BATCHDIR_ENV}/bin/activate"
+python3.10 -m uv pip freeze
+
+echo "sbatch preamble ========================================================="
+JOB_PREAMBLE=$(cat << EOF
+set -e
+shopt -s globstar
+
+# adapted from https://unix.stackexchange.com/a/504829
+handlefail() {
+    echo ">>>error<<<" || :
+    awk 'NR>L-4 && NR<L+4 { printf "%-5d%3s%s\n",NR,(NR==L?">>>":""),\$0 }' L=\$1 \$0 || :
+    ln -sfn "\${JOBSCRIPT}" "\${HOME}/joblatest/jobscript.failed" || :
+    ln -sfn "\${JOBLOG}" "\${HOME}/joblatest/joblog.failed" || :
+    $(which scontrol || which echo) requeuehold "${SLURM_JOBID:-nojid}"
+}
+trap 'handlefail $LINENO' ERR
+
+echo "initialization telemetry ------------------------------------ \${SECONDS}"
+echo "SOURCE_REVISION ${SOURCE_REVISION}"
+echo "BATCHDIR ${BATCHDIR}"
+
+echo "cc SLURM script --------------------------------------------- \${SECONDS}"
+JOBSCRIPT="\${HOME}/jobscript/\${SLURM_JOB_ID:-nojid}"
+echo "JOBSCRIPT \${JOBSCRIPT}"
+cp "\${0}" "\${JOBSCRIPT}"
+chmod +x "\${JOBSCRIPT}"
+cp "\${JOBSCRIPT}" "${BATCHDIR_JOBSCRIPT}/\${SLURM_JOB_ID:-nojid}"
+ln -sfn "\${JOBSCRIPT}" "${HOME}/joblatest/jobscript.launched"
+
+echo "cc job log -------------------------------------------------- \${SECONDS}"
+JOBLOG="\${HOME}/joblog/\${SLURM_JOB_ID:-nojid}"
+echo "JOBLOG \${JOBLOG}"
+touch "\${JOBLOG}"
+ln -sfn "\${JOBLOG}" "${BATCHDIR_JOBLOG}/\${SLURM_JOB_ID:-nojid}"
+ln -sfn "\${JOBLOG}" "\${HOME}/joblatest/joblog.launched"
+
+echo "setup JOBDIR ------------------------------------------------ \${SECONDS}"
+JOBDIR="${BATCHDIR}/__\${SLURM_ARRAY_TASK_ID:-\${SLURM_JOB_ID:-\${RANDOM}}}"
+echo "JOBDIR \${JOBDIR}"
+if [ -e "\${JOBDIR}" ]; then
+    echo "JOBDIR \${JOBDIR} exists, clearing it"
+fi
+rm -rf "\${JOBDIR}"
+mkdir -p "\${JOBDIR}"
+cd "\${JOBDIR}"
+echo "PWD \${PWD}"
+
+echo "job telemetry ----------------------------------------------- \${SECONDS}"
+echo "source SLURM_JOB_ID ${SLURM_JOB_ID:-nojid}"
+echo "current SLURM_JOB_ID \${SLURM_JOB_ID:-nojid}"
+echo "SLURM_ARRAY_TASK_ID \${SLURM_ARRAY_TASK_ID:-notid}"
+echo "hostname \$(hostname)"
+echo "date \$(date)"
+
+echo "module setup ------------------------------------------------ \${SECONDS}"
+module purge || :
+module load Python/3.10.8 || :
+echo "python3.10 \$(which python3.10)"
+echo "python3.10 --version \$(python3.10 --version)"
+
+echo "setup dependencies- ----------------------------------------- \${SECONDS}"
+source "${BATCHDIR_ENV}/bin/activate"
+python3.10 -m uv pip freeze
+
+EOF
+)
+
+echo "create sbatch file: work ==============================================="
+
+SBATCH_FILE="$(mktemp)"
+echo "SBATCH_FILE ${SBATCH_FILE}"
+
+###############################################################################
+# WORK ---------------------------------------------------------------------- #
+###############################################################################
+cat > "${SBATCH_FILE}" << EOF
+#!/bin/bash
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=16G
+#SBATCH --time=4:00:00
+#SBATCH --output="/mnt/home/%u/joblog/%j"
+#SBATCH --mail-user=mawni4ah2o@pomail.net
+#SBATCH --mail-type=FAIL,TIME_LIMIT,ARRAY_TASKS
+#SBATCH --account=beacon
+#SBATCH --requeue
+#SBATCH --array=0-$((N_TASKS - 1))
+
+${JOB_PREAMBLE}
+
+echo "lscpu ------------------------------------------------------- \${SECONDS}"
+lscpu || :
+
+echo "cpuinfo ----------------------------------------------------- \${SECONDS}"
+cat /proc/cpuinfo || :
+
+echo "task assignment --------------------------------------------- \${SECONDS}"
+NSITES_LIST=(${NSITES_LIST[*]})
+TASK_ID=\${SLURM_ARRAY_TASK_ID:-0}
+NSITES=\${NSITES_LIST[\$((TASK_ID / ${N_REPLICATES}))]}
+SEED=\$((TASK_ID % ${N_REPLICATES} + 1))
+echo "TASK_ID=\${TASK_ID} NSITES=\${NSITES} SEED=\${SEED}"
+
+echo "do work ----------------------------------------------------- \${SECONDS}"
+# Run the founder marimo notebook on CPU (engine=numpy, no GPU
+# requested in #SBATCH). --skip-plotting=True drops the per-replicate
+# teeplots --- the parquets are the deliverable. The notebook writes
+# parquets to \${JOBDIR}/outdata/${NOTEBOOK_NAME}/<kind>/<uid>/...
+# with simulation parameters (n_sites, pop_size, n_steps, seed, ...)
+# and a uuid replicate identifier stamped onto every row.
+MPLBACKEND=Agg python3.10 -m marimo export ipynb \
+    --include-outputs --sort topological -f \
+    "${BATCHDIR_JOBSOURCE}/${NOTEBOOK_PATH}" \
+    -o "\${JOBDIR}/${NOTEBOOK_NAME}.ipynb" \
+    -- \
+    --n-sites "\${NSITES}" \
+    --seed "\${SEED}" \
+    --n-steps ${N_STEPS} \
+    --pop-size ${POP_SIZE} \
+    --engine numpy \
+    --skip-plotting True
+
+echo "finalization telemetry -------------------------------------- \${SECONDS}"
+ls -lR "\${JOBDIR}" | head -200
+du -sh "\${JOBDIR}"
+ln -sfn "\${JOBSCRIPT}" "${HOME}/joblatest/jobscript.finished"
+ln -sfn "\${JOBLOG}" "${HOME}/joblatest/joblog.finished"
+echo "SECONDS \${SECONDS}"
+echo '>>>complete<<<'
+
+EOF
+###############################################################################
+# --------------------------------------------------------------------------- #
+###############################################################################
+
+
+echo "submit sbatch file ====================================================="
+$(which sbatch && echo --job-name="${JOBNAME}" || which bash) "${SBATCH_FILE}"
+
+echo "create sbatch file: collate ============================================"
+
+SBATCH_FILE="$(mktemp)"
+echo "SBATCH_FILE ${SBATCH_FILE}"
+
+###############################################################################
+# COLLATE ------------------------------------------------------------------- #
+###############################################################################
+cat > "${SBATCH_FILE}" << EOF
+#!/bin/bash
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=16G
+#SBATCH --time=4:00:00
+#SBATCH --output="/mnt/home/%u/joblog/%j"
+#SBATCH --mail-user=mawni4ah2o@pomail.net
+#SBATCH --mail-type=ALL
+#SBATCH --account=beacon
+#SBATCH --requeue
+
+${JOB_PREAMBLE}
+
+echo "BATCHDIR ${BATCHDIR}"
+ls -l "${BATCHDIR}"
+
+echo "finalize ---------------------------------------------------- \${SECONDS}"
+echo "   - archive job dir"
+pushd "${BATCHDIR}/.."
+    tar czf \
+    "${BATCHDIR_JOBRESULT}/a=jobarchive+date=${JOBDATE}+job=${JOBNAME}+ext=.tar.gz" \
+    "\$(basename "${BATCHDIR}")"/__*
+popd
+
+echo "   - join per-replicate parquets across all conditions"
+# Each per-replicate parquet already carries the replicate_uid plus the
+# condition columns (n_sites, pop_size, n_steps, seed, engine, pow,
+# mutation_rate, contact_rate, ...) stamped by the notebook's run cell,
+# so a straight concatenation yields a self-describing collated frame.
+# The strain parquet is the headline output --- one row per
+# (replicate_uid, Step, strain) recording the per-genome infection count
+# (n_cases) and new-infection count (n_new_infections) alongside the
+# population-fraction counterparts. The hw parquet aggregates those
+# per-genome counts by Hamming weight (n_cases per HW band).
+for kind in strain hw traj records phylo; do
+    echo "    joining \${kind} ..."
+    out_path="${BATCHDIR_JOBRESULT}/a=\${kind}+date=${JOBDATE}+job=${JOBNAME}+ext=.pqt"
+    ls -1 "${BATCHDIR}"/__*/outdata/${NOTEBOOK_NAME}/\${kind}/*/a=\${kind}+*+ext=.pqt 2>/dev/null \
+        | tee /dev/stderr \
+        | python3.10 -m joinem --progress "\${out_path}" \
+        || echo "no \${kind} files to join"
+done
+ls -l "${BATCHDIR_JOBRESULT}"
+du -h "${BATCHDIR_JOBRESULT}"
+
+echo "   - archive joblog"
+pushd "${BATCHDIR}"
+    tar czf \
+    "${BATCHDIR_JOBRESULT}/a=joblog+date=${JOBDATE}+job=${JOBNAME}+ext=.tar.gz" \
+    -h "\$(basename "${BATCHDIR_JOBLOG}")"
+popd
+
+echo "   - archive jobscript"
+pushd "${BATCHDIR}"
+    tar czf \
+    "\$(basename "${BATCHDIR_JOBRESULT}")/a=jobscript+date=${JOBDATE}+job=${JOBNAME}+ext=.tar.gz" \
+    -h "\$(basename ${BATCHDIR_JOBSCRIPT})"
+popd
+
+ls -l "${BATCHDIR}"
+
+echo "cleanup ----------------------------------------------------- \${SECONDS}"
+cd "${BATCHDIR}"
+for f in _*; do
+    echo "tar and rm \$f"
+    tar cf "\${f}.tar" -h "\${f}"
+    rm -rf "\${f}"
+done
+cd
+ls -l "${BATCHDIR}"
+
+echo "finalization telemetry -------------------------------------- \${SECONDS}"
+ln -sfn "\${JOBSCRIPT}" "\${HOME}/joblatest/jobscript.completed"
+ln -sfn "\${JOBLOG}" "\${HOME}/joblatest/joblog.completed"
+ln -sfn "${BATCHDIR_JOBRESULT}" "\${HOME}/joblatest/jobresult.completed"
+echo "SECONDS \${SECONDS}"
+echo '>>>complete<<<'
+
+EOF
+###############################################################################
+# --------------------------------------------------------------------------- #
+###############################################################################
+
+echo "submit sbatch file ====================================================="
+$(which sbatch && echo --job-name="${JOBNAME}" --dependency=singleton || which bash) "${SBATCH_FILE}"
+
+echo "finalization telemetry ================================================="
+echo "BATCHDIR ${BATCHDIR}"
+echo "SECONDS ${SECONDS}"
+echo '>>>complete<<<'


### PR DESCRIPTION
## Summary
This PR adds a new marimo notebook (`2026-05-20-founder.py`) that implements a single-replicate, command-line-driven version of the allele-based agent-based model (ABM) for pathogen evolution. It serves as a companion to the multi-condition sweep notebook, reusing the same simulation, reconstruction, and visualization logic but optimized for running individual replicates with configurable parameters.

## Key Changes

- **New founder notebook**: Implements a complete ABM simulation pipeline with the following features:
  - Vectorized population dynamics simulation supporting both CPU (NumPy) and GPU (CuPy) backends
  - Per-step tracking of Hamming-weight and strain-level prevalence
  - Hereditary stratigraphic surface annotations for phylogeny reconstruction using hstrat
  - Command-line argument parsing for all simulation parameters (seed, N_SITES, population size, steps, etc.)

- **Simulation implementation** (`simulate()` function):
  - Tracks host infection status, pathogen genomes, and immune history
  - Models contact-based transmission with strain-specific susceptibility based on allele-level immunity
  - Implements within-host mutation dynamics with optional mutator hosts
  - Computes both actual and expected per-strain reproduction numbers (R values)
  - Supports immunity waning and ceiling/floor constraints
  - Deposits stratigraphic markers for phylogenetic inference

- **Phylogeny reconstruction** (`reconstruct_phylogeny()` function):
  - Unpacks surface annotations and builds phylogenetic trees using hstrat
  - Assigns origin times aligned with simulation steps
  - Validates and post-processes tree structure

- **Visualization functions**:
  - `make_phylogeny_plot()`: Renders surface-reconstructed phylogeny alongside Hamming-weight stackplots and density heatmaps
  - `make_strain_curves_plot()`: Two-panel figure showing per-strain susceptibility and prevalence trajectories
  - `make_strain_summary_plot()`: Three-panel figure combining expected R, susceptibility, and case burden
  - `make_r_curves_plot()`: Multi-row R-value trajectories with rolling-mean smoothing
  - `make_strain_graph_plot()`: Network visualization of strain relationships at varying Hamming distances
  - `make_hamming_stackplot()`: Stacked area chart of Hamming-weight prevalence over time
  - `make_hamming_heatmap()`: Density heatmap of Hamming-distance distributions

## Notable Implementation Details

- **Genome representation**: Uses smallest unsigned integer dtype (uint16/uint32/uint64) that accommodates N_SITES bits, supporting up to 64-site sweeps
- **Susceptibility computation**: Per-host susceptibility is the product of allele-specific immunity values, with optional exponent (`pow` parameter) for non-linear dose-response
- **R-value scaling**: Both actual and expected R values are scaled by `(1 - RECOVERY_RATE) / RECOVERY_RATE` to account for discrete-time dynamics and within-step recovery ordering
- **Memory-gated computations**: Dense susceptibility tensors are only computed when below a 2GB threshold; per-strain figures are skipped when strain count exceeds 16
- **Phylogeny sampling**: Supports sampling up to N_SAMPLE extant hosts for phylogenetic reconstruction when population is large
- **Teeplot integration**: All figures use teeplot for flexible output handling (display, save, etc.)

https://claude.ai/code/session_01FsrwSxEmaDwB167R6tmNRj