### PR TITLE
Add per-strain transmissibility parameter to ABM model

### DIFF
--- a/binder/2026-06-17-strain-transmissibility.ipynb
+++ b/binder/2026-06-17-strain-transmissibility.ipynb
@@ -1,0 +1,289 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Per-Strain Transmissibility\n",
+    "\n",
+    "This notebook exercises the multiplicative per-strain `TRANSMISSIBILITY`\n",
+    "parameter added to the `abm_2026_03_16` model.\n",
+    "\n",
+    "`TRANSMISSIBILITY` scales the per-contact infection probability of the\n",
+    "*transmitting* strain. It defaults to `1.0` (no effect) and may be supplied\n",
+    "either as\n",
+    "\n",
+    "- a **scalar**, applied uniformly to every strain, or\n",
+    "- a **per-strain vector** of length `2 ** N_SITES`, indexed by genome\n",
+    "  integer (passed as a hashable `tuple` because `simulate` is `lru_cache`-d).\n",
+    "\n",
+    "We run a small condition matrix to confirm the parameter behaves as expected:\n",
+    "a global boost raises overall prevalence, and a per-strain vector reshapes the\n",
+    "competitive balance between strains.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Environment Setup\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext watermark\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import itertools as it\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import pylib  # noqa: F401\n",
+    "from pylib.abm_2026_03_16 import simulate\n",
+    "import seaborn as sns\n",
+    "from teeplot import teeplot as tp\n",
+    "from tqdm.auto import tqdm\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "teeplot_subdir = \"2026-06-17-strain-transmissibility\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%watermark -diwmuv -iv\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Transmissibility Conditions\n",
+    "\n",
+    "With `N_SITES = 2` there are `2 ** 2 == 4` strains, indexed by genome integer\n",
+    "`0..3` (bit `s` set means site `s` carries the mutant allele). The vector\n",
+    "conditions below are ordered by genome integer.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CONDITIONS = {\n",
+    "    # scalar: uniform across all strains (model default)\n",
+    "    \"uniform (1.0)\": 1.0,\n",
+    "    # scalar: global transmissibility boost\n",
+    "    \"global boost (1.5)\": 1.5,\n",
+    "    # vector: transmissibility rises with mutational load\n",
+    "    \"mutant advantage\": (1.0, 1.5, 1.5, 2.25),\n",
+    "    # vector: wildtype favored, double-mutant penalized\n",
+    "    \"wildtype advantage\": (2.0, 1.0, 1.0, 0.5),\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def transmissibility_caption(T) -> str:\n",
+    "    \"\"\"Render a condition's transmissibility as a short label.\"\"\"\n",
+    "    if np.ndim(T) == 0:\n",
+    "        return f\"scalar {T}\"\n",
+    "    return \"vector (\" + \", \".join(map(str, T)) + \")\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run Condition Matrix\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_REP = 3\n",
+    "N_STEPS = 400\n",
+    "POP_SIZE = 50_000\n",
+    "N_SITES = 2\n",
+    "MUTATION_RATE = 5e-5\n",
+    "\n",
+    "frames = []\n",
+    "for (label, TRANSMISSIBILITY), rep in tqdm(\n",
+    "    [*it.product(CONDITIONS.items(), range(N_REP))]\n",
+    "):\n",
+    "    result = simulate(\n",
+    "        N_SITES=N_SITES,\n",
+    "        POP_SIZE=POP_SIZE,\n",
+    "        N_STEPS=N_STEPS,\n",
+    "        MUTATION_RATE=MUTATION_RATE,\n",
+    "        TRANSMISSIBILITY=TRANSMISSIBILITY,\n",
+    "        seed=rep,\n",
+    "    ).copy()\n",
+    "    result[\"Condition\"] = label\n",
+    "    frames.append(result)\n",
+    "\n",
+    "df = pd.concat(frames, ignore_index=True).fillna(0)\n",
+    "df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overall Prevalence Across Conditions\n",
+    "\n",
+    "A larger transmissibility multiplier should drive higher overall prevalence.\n",
+    "The median across replicates is shown with a shaded full-range band.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with tp.teed(\n",
+    "    sns.relplot,\n",
+    "    data=df,\n",
+    "    x=\"Step\",\n",
+    "    y=\"Total_Infected\",\n",
+    "    hue=\"Condition\",\n",
+    "    kind=\"line\",\n",
+    "    estimator=np.median,\n",
+    "    errorbar=(\"pi\", 100),\n",
+    "    err_kws=dict(alpha=0.15),\n",
+    "    facet_kws=dict(margin_titles=True),\n",
+    "    teeplot_outattrs={\"what\": \"total-infected\"},\n",
+    "    teeplot_subdir=teeplot_subdir,\n",
+    ") as g:\n",
+    "    for ax in g.axes.flat:\n",
+    "        ax.grid(True, alpha=0.3)\n",
+    "    g.set_axis_labels(\"Step\", \"Fraction Infected\")\n",
+    "    g.figure.set_size_inches(w=5, h=3)\n",
+    "    sns.move_legend(\n",
+    "        g, \"center left\", bbox_to_anchor=(0.95, 0.5), frameon=False\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Per-Strain Prevalence Across Conditions\n",
+    "\n",
+    "Per-strain trajectories reveal how scalar versus vector transmissibility\n",
+    "reshape competition between strains.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "strain_df = (\n",
+    "    df.filter(regex=\"Step|Seed|Condition|Strain\", axis=1)\n",
+    "    .melt(\n",
+    "        id_vars=[\"Step\", \"Seed\", \"Condition\"],\n",
+    "        var_name=\"Strain\",\n",
+    "        value_name=\"Prevalence\",\n",
+    "    )\n",
+    "    .astype({\"Step\": int, \"Strain\": str, \"Prevalence\": float})\n",
+    ")\n",
+    "palette = dict(\n",
+    "    zip(\n",
+    "        sorted(strain_df[\"Strain\"].unique()),\n",
+    "        sns.color_palette(\"colorblind\", strain_df[\"Strain\"].nunique()),\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "with tp.teed(\n",
+    "    sns.relplot,\n",
+    "    data=strain_df,\n",
+    "    x=\"Step\",\n",
+    "    y=\"Prevalence\",\n",
+    "    hue=\"Strain\",\n",
+    "    col=\"Condition\",\n",
+    "    col_wrap=2,\n",
+    "    kind=\"line\",\n",
+    "    estimator=np.median,\n",
+    "    errorbar=(\"pi\", 100),\n",
+    "    err_kws=dict(alpha=0.1),\n",
+    "    palette=palette,\n",
+    "    facet_kws=dict(margin_titles=True),\n",
+    "    teeplot_outattrs={\"what\": \"per-strain\"},\n",
+    "    teeplot_subdir=teeplot_subdir,\n",
+    ") as g:\n",
+    "    for ax in g.axes.flat:\n",
+    "        ax.grid(True, alpha=0.3)\n",
+    "    g.set(yscale=\"log\", ylim=(1 / POP_SIZE, 1.1))\n",
+    "    g.figure.set_size_inches(w=6, h=5)\n",
+    "    sns.move_legend(\n",
+    "        g, \"center left\", bbox_to_anchor=(0.95, 0.5), frameon=False\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sanity Check: Endpoint Prevalence\n",
+    "\n",
+    "A succinct numerical confirmation that scalar transmissibility is monotonic in\n",
+    "overall prevalence, and that the per-strain vectors shift which strains\n",
+    "dominate. Reported as the median final-step prevalence across replicates.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary = (\n",
+    "    df.groupby(\"Condition\")\n",
+    "    .apply(\n",
+    "        lambda g: g[g[\"Step\"] == g[\"Step\"].max()].median(numeric_only=True),\n",
+    "        include_groups=False,\n",
+    "    )\n",
+    "    .filter(regex=\"Total_Infected|Strain\")\n",
+    "    .round(4)\n",
+    ")\n",
+    "summary\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pylib/abm_2026_03_16/_simulate.py
+++ b/pylib/abm_2026_03_16/_simulate.py
@@ -31,8 +31,13 @@ def simulate(
     MUTATION_THRESHOLD: float = 0.0,
     IMMUNITY_CEILING: float = 1.0,
     IMMUNITY_FLOOR: float = 0.0,
+    TRANSMISSIBILITY: Union[float, Sequence[float]] = 1.0,
     xp=None,
 ) -> pd.DataFrame:
+    # NOTE: ``simulate`` is ``lru_cache``-d, so a per-strain
+    # ``TRANSMISSIBILITY`` vector must be passed as a hashable tuple of length
+    # ``2 ** N_SITES`` (indexed by genome integer). A scalar applies to all
+    # strains; the default of 1.0 leaves transmission unchanged.
     if xp is None:
         xp = _xp
 
@@ -72,6 +77,7 @@ def simulate(
             MUTATION_THRESHOLD,
             IMMUNITY_CEILING,
             IMMUNITY_FLOOR,
+            TRANSMISSIBILITY,
             xp=xp,
         )
 

--- a/pylib/abm_2026_03_16/_transmit_infection.py
+++ b/pylib/abm_2026_03_16/_transmit_infection.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Sequence, Tuple, Union
 
 from ._auxlib import xp as _xp
 from ._calc_infection_probabilities import calc_infection_probabilities
@@ -12,15 +12,30 @@ def transmit_infection(
     N_SITES: int,
     CONTACT_RATE: float,
     IMMUNE_STRENGTH: float,
+    TRANSMISSIBILITY: Union[float, Sequence[float]] = 1.0,
     xp=None,
 ) -> Tuple:
-    """Vectorized transmission based on allele-specific susceptibility."""
+    """Vectorized transmission based on allele-specific susceptibility.
+
+    ``TRANSMISSIBILITY`` is a multiplicative factor applied to the
+    transmitting strain's infection probability. It may be a scalar (applied
+    to all strains) or a per-strain vector of length ``2 ** N_SITES`` indexed
+    by genome integer.
+    """
     if xp is None:
         xp = _xp
 
     contacts = xp.random.randint(
         low=0, high=POP_SIZE, size=POP_SIZE, dtype=xp.uint32
     )
+
+    TRANSMISSIBILITY = xp.asarray(TRANSMISSIBILITY, dtype=xp.float32)
+    if TRANSMISSIBILITY.size == 1:
+        strain_transmissibility = TRANSMISSIBILITY
+    else:
+        # index per-strain factor by the transmitting contact's genome
+        strain_transmissibility = TRANSMISSIBILITY[pathogen_genomes[contacts]]
+
     inf_probs = (
         calc_infection_probabilities(
             host_immunities,
@@ -33,6 +48,7 @@ def transmit_infection(
         * (host_statuses == 0)
         * (host_statuses[contacts] > 0)
         * CONTACT_RATE
+        * strain_transmissibility
     )
 
     new_infections = xp.random.rand(POP_SIZE) < inf_probs

--- a/pylib/abm_2026_03_16/_update_simulation.py
+++ b/pylib/abm_2026_03_16/_update_simulation.py
@@ -25,6 +25,7 @@ def update_simulation(
     MUTATION_THRESHOLD: float = 0.0,
     IMMUNITY_CEILING: float = 1.0,
     IMMUNITY_FLOOR: float = 0.0,
+    TRANSMISSIBILITY=1.0,
     xp=None,
 ) -> Tuple:
     """Run one step of the simulation."""
@@ -39,6 +40,7 @@ def update_simulation(
         N_SITES,
         CONTACT_RATE,
         IMMUNE_STRENGTH,
+        TRANSMISSIBILITY,
         xp=xp,
     )
     pathogen_genomes = apply_mutations(

--- a/tests/test_pylib/test_abm_2026_03_16/test_transmit_infection.py
+++ b/tests/test_pylib/test_abm_2026_03_16/test_transmit_infection.py
@@ -67,3 +67,80 @@ def test_transmission_preserves_genomes():
     newly_infected = host_statuses == 1
     if np.any(newly_infected):
         assert np.all(pathogen_genomes[newly_infected] == 3)
+
+
+def test_scalar_transmissibility_zero_blocks_transmission():
+    np.random.seed(42)
+    POP_SIZE = 1000
+    N_SITES = 1
+    host_statuses = np.zeros(POP_SIZE, dtype=np.uint8)
+    host_statuses[:100] = 5
+    pathogen_genomes = np.zeros(POP_SIZE, dtype=np.uint8)
+    host_immunities = np.zeros((POP_SIZE, 2 * N_SITES), dtype=np.float32)
+
+    host_statuses, pathogen_genomes = transmit_infection(
+        host_statuses,
+        pathogen_genomes,
+        host_immunities,
+        POP_SIZE=POP_SIZE,
+        N_SITES=N_SITES,
+        CONTACT_RATE=1.0,
+        IMMUNE_STRENGTH=0.0,
+        TRANSMISSIBILITY=0.0,
+    )
+    assert np.sum(host_statuses == 1) == 0
+
+
+def test_scalar_transmissibility_default_matches_one():
+    POP_SIZE = 1000
+    N_SITES = 1
+    args = dict(
+        POP_SIZE=POP_SIZE,
+        N_SITES=N_SITES,
+        CONTACT_RATE=1.0,
+        IMMUNE_STRENGTH=0.0,
+    )
+
+    def setup():
+        host_statuses = np.zeros(POP_SIZE, dtype=np.uint8)
+        host_statuses[:100] = 5
+        pathogen_genomes = np.zeros(POP_SIZE, dtype=np.uint8)
+        host_immunities = np.zeros((POP_SIZE, 2 * N_SITES), dtype=np.float32)
+        return host_statuses, pathogen_genomes, host_immunities
+
+    np.random.seed(42)
+    default_statuses, _ = transmit_infection(*setup(), **args)
+    np.random.seed(42)
+    explicit_statuses, _ = transmit_infection(
+        *setup(), TRANSMISSIBILITY=1.0, **args
+    )
+    assert np.array_equal(default_statuses, explicit_statuses)
+
+
+def test_per_strain_transmissibility_vector_blocks_one_strain():
+    np.random.seed(42)
+    POP_SIZE = 2000
+    N_SITES = 1
+    host_statuses = np.zeros(POP_SIZE, dtype=np.uint8)
+    # genome 0 infects first half, genome 1 infects second half
+    host_statuses[:500] = 5
+    host_statuses[1000:1500] = 5
+    pathogen_genomes = np.zeros(POP_SIZE, dtype=np.uint8)
+    pathogen_genomes[1000:1500] = 1
+    host_immunities = np.zeros((POP_SIZE, 2 * N_SITES), dtype=np.float32)
+
+    # strain 0 cannot transmit, strain 1 can
+    host_statuses, pathogen_genomes = transmit_infection(
+        host_statuses,
+        pathogen_genomes,
+        host_immunities,
+        POP_SIZE=POP_SIZE,
+        N_SITES=N_SITES,
+        CONTACT_RATE=1.0,
+        IMMUNE_STRENGTH=0.0,
+        TRANSMISSIBILITY=(0.0, 1.0),
+    )
+    newly_infected = host_statuses == 1
+    assert np.any(newly_infected)
+    # all new infections must be the transmissible strain (genome 1)
+    assert np.all(pathogen_genomes[newly_infected] == 1)


### PR DESCRIPTION
## Summary
This PR adds a new `TRANSMISSIBILITY` parameter to the ABM model that allows multiplicative scaling of infection probabilities on a per-strain basis. The parameter can be specified as either a scalar (applied uniformly to all strains) or as a per-strain vector indexed by genome integer.

## Key Changes
- **New parameter `TRANSMISSIBILITY`**: Added to `transmit_infection()`, `update_simulation()`, and `simulate()` functions
  - Defaults to `1.0` (no effect on transmission)
  - Accepts scalar values for uniform scaling across all strains
  - Accepts per-strain vectors of length `2 ** N_SITES` (indexed by genome integer) for differential strain transmissibility
  - Vectors must be passed as tuples to `simulate()` since it uses `lru_cache`

- **Implementation in `_transmit_infection.py`**:
  - Converts `TRANSMISSIBILITY` to array and handles both scalar and vector cases
  - For vector case, indexes into the per-strain factors using the transmitting contact's genome
  - Multiplies infection probabilities by the appropriate strain transmissibility factor

- **Comprehensive test coverage** in `test_transmit_infection.py`:
  - `test_scalar_transmissibility_zero_blocks_transmission()`: Verifies zero transmissibility blocks all transmission
  - `test_scalar_transmissibility_default_matches_one()`: Confirms default behavior matches explicit `1.0`
  - `test_per_strain_transmissibility_vector_blocks_one_strain()`: Validates per-strain vector selectively blocks transmission

- **Demonstration notebook** (`2026-06-17-strain-transmissibility.ipynb`):
  - Exercises the new parameter with four conditions: uniform baseline, global boost, mutant advantage, and wildtype advantage
  - Visualizes overall prevalence and per-strain dynamics across conditions
  - Confirms scalar transmissibility monotonically affects overall prevalence
  - Shows per-strain vectors reshape competitive balance between strains

## Notable Implementation Details
- The per-strain vector approach enables modeling of strain-specific fitness differences and selective transmission advantages
- Scalar transmissibility provides a simple way to globally scale transmission (e.g., for modeling environmental or behavioral changes)
- The parameter integrates seamlessly with existing immunity and contact rate mechanisms

https://claude.ai/code/session_01CKNEWPPf8Cebtx8aYE87Yq