### PR TITLE
Label community assembly graph edges with +/- strain transitions

### DIFF
--- a/bindle/2026-06-24-community-assembly-graph.py
+++ b/bindle/2026-06-24-community-assembly-graph.py
@@ -357,6 +357,18 @@ def def_assemble(
         """Special end node (complement pair or U) vs. transient community."""
         return isinstance(key, str)
 
+    def edge_delta_label(a, b):
+        """Strain-level transition label, e.g. "+100" (introduced) or
+        "-010" (went extinct); "" for transitions into a special end
+        node (complement-pair collapse or non-convergence), which are
+        not single-strain events.
+        """
+        if is_end_key(a) or is_end_key(b):
+            return ""
+        parts = [f"+{binstr(s)}" for s in sorted(b - a)]
+        parts += [f"-{binstr(s)}" for s in sorted(a - b)]
+        return ",".join(parts)
+
     def assemble(uid, rep_df):
         """Build a replicate's transition sequence.
 
@@ -450,6 +462,7 @@ def def_assemble(
         PAIR_KEYS,
         assemble,
         binstr,
+        edge_delta_label,
         is_end_key,
         node_count_label,
         node_text,
@@ -489,7 +502,10 @@ def delimit_examples(mo):
     node it converged to (`000/111`, `001/110`, `010/101`, `011/100`),
     while a non-converging run terminates in **`U`**. The `000/111` pair
     (wildtype + all-ones) is outlined **green** and `U` is outlined
-    **red**; the other pairs get their own outline colors.
+    **red**; the other pairs get their own outline colors. Edges between
+    transient communities are labelled with the strain that was
+    introduced (`+100`) or went extinct (`-010`) in that transition; the
+    final edge into a special end node is left unlabelled.
     """
     )
     return
@@ -498,6 +514,7 @@ def delimit_examples(mo):
 @app.cell
 def def_plot_path(
     END_OUTLINE,
+    edge_delta_label,
     ig,
     iplotx,
     is_end_key,
@@ -535,10 +552,12 @@ def def_plot_path(
                 vlw.append(1.0)
             vlabel.append(node_count_label(k))
             vsize.append(34.0 if last else 26.0)
+        elabel = [edge_delta_label(keys[i], keys[i + 1]) for i in range(n - 1)]
         iplotx.network(
             g,
             layout=coords,
             vertex_labels=vlabel,
+            edge_labels=elabel,
             ax=ax,
             vertex_facecolor=vface,
             vertex_edgecolor=vedge,
@@ -548,6 +567,8 @@ def def_plot_path(
             edge_color="0.55",
             vertex_label_color="black",
             vertex_label_size=9,
+            edge_label_size=7,
+            edge_label_rotate=False,
             show=False,
         )
         ax.margins(0.15)
@@ -871,15 +892,18 @@ def delimit_plot(mo):
     **number on each node is the count of present strains** (the
     complement-pair end nodes hold 2). Special end-node sizes reflect
     end-node occurrence; transient node sizes reflect transient occurrence
-    (separate scales). Edge width encodes transition frequency and each
-    edge label is the 2-digit percentage of its source's outgoing
-    transitions. The `000/111` complement-pair end node is outlined
-    **green** and the non-convergence `U` end node **red**; the remaining
-    pairs carry their own outline colors.
+    (separate scales). Edge width encodes transition frequency. The
+    `000/111` complement-pair end node is outlined **green** and the
+    non-convergence `U` end node **red**; the remaining pairs carry their
+    own outline colors.
 
-    Two versions of each graph are rendered and saved (tagged via
-    `teeplot_outattrs` `edge-labels=pct` vs `edge-labels=none`): one with
-    the edge percentage labels and one with bare arrows.
+    Three versions of each graph are rendered and saved (tagged via
+    `teeplot_outattrs` `edge-labels=pct` vs `edge-labels=delta` vs
+    `edge-labels=none`): one with each edge labelled by the 2-digit
+    percentage of its source's outgoing transitions, one with each edge
+    between transient communities labelled by the strain introduced
+    (`+100`) or gone extinct (`-010`) in that transition (edges into a
+    special end node are left unlabelled), and one with bare arrows.
     """
     )
     return
@@ -924,6 +948,7 @@ def def_layout(defaultdict, is_end_key, np):
 @app.cell
 def def_plot_mu(
     END_OUTLINE,
+    edge_delta_label,
     ig,
     iplotx,
     is_end_key,
@@ -934,7 +959,9 @@ def def_plot_mu(
     plt,
     sns,
 ):
-    def plot_mu(mu, bundle, ax, legend_ax, palette="husl", edge_labels=True):
+    def plot_mu(
+        mu, bundle, ax, legend_ax, palette="husl", edge_label_mode="pct"
+    ):
         agg = bundle["agg"]
         keep = bundle["keep"]
         kept_edges = bundle["edges"]
@@ -958,14 +985,18 @@ def def_plot_mu(
 
         g = ig.Graph(directed=True)
         g.add_vertices(len(nodes))
-        elist, ewidth, elabel = [], [], []
+        elist, ewidth, elabel_pct, elabel_delta = [], [], [], []
         max_e = max(kept_edges.values()) if kept_edges else 1
         for (a, b), c in kept_edges.items():
             elist.append((idx[a], idx[b]))
             ewidth.append(1.0 + 4.0 * (c / max_e))
             pct = 100.0 * c / max(agg["out_total"].get(a, c), 1)
-            elabel.append(f"{min(pct, 99):02.0f}%")
+            elabel_pct.append(f"{min(pct, 99):02.0f}%")
+            elabel_delta.append(edge_delta_label(a, b))
         g.add_edges(elist)
+        elabel = {"pct": elabel_pct, "delta": elabel_delta, "none": None}[
+            edge_label_mode
+        ]
 
         colors = sns.color_palette(
             palette,
@@ -993,7 +1024,7 @@ def def_plot_mu(
             g,
             layout=[coords[k] for k in nodes],
             vertex_labels=vlabel,
-            edge_labels=(elabel if edge_labels else None),
+            edge_labels=elabel,
             ax=ax,
             vertex_facecolor=vface,
             vertex_edgecolor=vedge,
@@ -1003,7 +1034,7 @@ def def_plot_mu(
             edge_color="0.55",
             vertex_label_color="black",
             vertex_label_size=8,
-            edge_label_size=6,
+            edge_label_size=7,
             edge_label_rotate=False,
             show=False,
         )
@@ -1063,8 +1094,9 @@ def def_plot_mu(
 
 @app.cell
 def render_graphs(aggregates, mutation_rates, pathlib, plot_mu, plt, tp):
-    # Render two versions per mutation rate: one with the edge percentage
-    # labels and one without (arrows only). teeplot_outattrs tag them apart.
+    # Render three versions per mutation rate: edge percentage labels,
+    # strain-level +/- transition labels, and bare arrows (no labels).
+    # teeplot_outattrs tags them apart.
     for _mu in mutation_rates:
         _bundle = aggregates[_mu]
         _n_nodes = len(_bundle["keep"])
@@ -1076,7 +1108,7 @@ def render_graphs(aggregates, mutation_rates, pathlib, plot_mu, plt, tp):
             )
             return fig, (ax, lax)
 
-        for _edge_labels, _tag in [(True, "pct"), (False, "none")]:
+        for _tag in ("pct", "delta", "none"):
             with tp.teed(
                 _factory,
                 figsize=(14 if _wide else 13, 8.5 if _wide else 7.5),
@@ -1089,7 +1121,7 @@ def render_graphs(aggregates, mutation_rates, pathlib, plot_mu, plt, tp):
                 teeplot_show=True,
                 teeplot_subdir=pathlib.Path(__file__).stem,
             ) as (fig, (ax, lax)):
-                plot_mu(_mu, _bundle, ax, lax, edge_labels=_edge_labels)
+                plot_mu(_mu, _bundle, ax, lax, edge_label_mode=_tag)
     return
 
 


### PR DESCRIPTION
Add a small edge label (e.g. "+100" introduced, "-010" went extinct)
to both the per-replicate example paths (Section 3) and a new "delta"
teeplot variant of the combined per-mutation-rate graphs (Section 5,
alongside the existing percentage and unlabeled variants).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M6rSrigkYB3R5MHam9D7xm