### PR TITLE
Add 3-site strain-persistence community-assembly array job

### DIFF
--- a/bindle/2026-07-14-community-assembly-invasion.py
+++ b/bindle/2026-07-14-community-assembly-invasion.py
@@ -264,12 +264,12 @@ def def_graph(N_SITES, deque, itertools, susc_map):
     def _permute_genome(g, perm):
         return sum((1 << perm[i]) for i in range(N_SITES) if (g >> i) & 1)
 
-    def canon(community):
-        """Arrival-order canonical form: symmetry-minimal genome set.
+    def canon_perm(community):
+        """Canonical form plus the site permutation that produces it.
 
-        Relabels sites so the first-arriving site is bit 0, etc. --- the
-        lexicographically smallest genome frozenset over all site
-        permutations. Symmetric communities share one canonical node.
+        Returns ``(canonical_set, perm)`` where ``perm`` maps site ``i`` of
+        the input frame to site ``perm[i]`` of the canonical frame (the
+        symmetry-minimal genome frozenset over all site permutations).
         """
         best_key = None
         best = None
@@ -277,8 +277,16 @@ def def_graph(N_SITES, deque, itertools, susc_map):
             mapped = frozenset(_permute_genome(g, perm) for g in community)
             key = tuple(sorted(mapped))
             if best_key is None or key < best_key:
-                best_key, best = key, mapped
+                best_key, best = key, (mapped, perm)
         return best
+
+    def canon(community):
+        """Arrival-order canonical form: symmetry-minimal genome set.
+
+        Relabels sites so the first-arriving site is bit 0, etc. Symmetric
+        communities share one canonical node.
+        """
+        return canon_perm(community)[0]
 
     def bitmask(community):
         m = 0
@@ -303,7 +311,8 @@ def def_graph(N_SITES, deque, itertools, susc_map):
         """BFS from the 000 founder; returns (nodes, edges).
 
         nodes: set of canonical community frozensets.
-        edges: dict (src_tuple, dst_tuple) -> (invader_strain, susc).
+        edges: dict (src_tuple, dst_tuple) -> (label, susc); every edge is a
+        pure gain, labelled ``+<invader>`` in the source frame.
         """
         root = canon(frozenset({0}))
         nodes = {root}
@@ -315,8 +324,9 @@ def def_graph(N_SITES, deque, itertools, susc_map):
                 if susc <= susc_threshold:
                     continue
                 child = canon(community | {strain})
+                label = f"+{format(int(strain), f'0{N_SITES}b')}"
                 edges[(tuple(sorted(community)), tuple(sorted(child)))] = (
-                    int(strain),
+                    label,
                     susc,
                 )
                 if child not in nodes:
@@ -324,7 +334,7 @@ def def_graph(N_SITES, deque, itertools, susc_map):
                     queue.append(child)
         return nodes, edges
 
-    return bitmask, build_assembly_graph, canon, invaders
+    return bitmask, build_assembly_graph, canon, canon_perm, invaders
 
 
 @app.cell
@@ -537,15 +547,27 @@ def delimit_extinction(mo):
 
 
 @app.cell
-def def_extinction_graph(bitmask, canon, deque, invaders, last_map):
-    def survivors(community, threshold):
-        """Strains of `community` still present at update >= threshold.
+def def_extinction_graph(
+    N_SITES, bitmask, canon, canon_perm, deque, invaders, last_map
+):
+    def _survivors_in_frame(community, threshold):
+        """Members of `community` surviving to `threshold`, kept in the input
+        frame (not re-canonicalized), so the gained/lost taxa can be read off
+        in the *parent* frame. Survival is looked up in the community's own
+        even-mix run via the permutation to its canonical array_id."""
+        canonical, perm = canon_perm(community)
+        last = last_map[bitmask(canonical)]
 
-        Read from the community's own even-mix seeded run (strainlast),
-        then re-canonicalized (extinction can leave a non-canonical subset).
-        """
-        last = last_map[bitmask(community)]
-        return canon(frozenset(g for g in community if last[g] >= threshold))
+        def survives(g):
+            mapped = sum(
+                (1 << perm[i]) for i in range(N_SITES) if (g >> i) & 1
+            )
+            return last[mapped] >= threshold
+
+        return frozenset(g for g in community if survives(g))
+
+    def survivors(community, threshold):
+        return canon(_survivors_in_frame(community, threshold))
 
     def build_extinction_graph(window, susc_threshold, ext_threshold):
         """Assembly with extinctions resolved before each further addition.
@@ -554,8 +576,11 @@ def def_extinction_graph(bitmask, canon, deque, invaders, last_map):
         community C' an admissible single-mutation invader (window
         susceptibility > susc_threshold) is added, then the even-mix outcome
         of C' + {x} prunes strains not surviving to ext_threshold, giving the
-        next post-extinction community. Self-transitions (surviving set
-        unchanged) and collapses to the empty set are dropped.
+        next post-extinction community. Each edge is labelled with the
+        *parent-frame* net change --- ``+<invader>`` for the strain that
+        established plus ``-<resident>`` for each resident it drove extinct.
+        Self-transitions (surviving set unchanged) and collapses to the empty
+        set are dropped.
         """
         root = survivors(canon(frozenset({0})), ext_threshold)
         nodes = {root}
@@ -568,11 +593,19 @@ def def_extinction_graph(bitmask, canon, deque, invaders, last_map):
             for strain, susc in invaders(community, window):
                 if susc <= susc_threshold:
                     continue
-                nxt = survivors(canon(community | {strain}), ext_threshold)
+                assembled = community | {strain}
+                surv = _survivors_in_frame(assembled, ext_threshold)
+                nxt = canon(surv)
                 if nxt == community or not nxt:
                     continue
+                gained = sorted(surv - community)
+                lost = sorted(community - surv)
+                label = " ".join(
+                    [f"+{format(g, f'0{N_SITES}b')}" for g in gained]
+                    + [f"-{format(g, f'0{N_SITES}b')}" for g in lost]
+                )
                 edges[(tuple(sorted(community)), tuple(sorted(nxt)))] = (
-                    int(strain),
+                    label,
                     susc,
                 )
                 if nxt not in nodes:
@@ -630,12 +663,12 @@ def peek_graph(N_SITES, graphs):
         _i = sorted(graphs)[0]
         _g = graphs[_i]
         print(f"sample {_i} (window end {_g['window_end']}):")
-        for (a, b), (x, susc) in sorted(
+        for (a, b), (label, susc) in sorted(
             _g["edges"].items(), key=lambda kv: (len(kv[0][0]), kv[0])
         ):
             print(
-                f"  {_binset(a)} --{format(x, f'0{N_SITES}b')}"
-                f" (susc={susc:.3f})--> {_binset(b)}"
+                f"  {_binset(a)} --[{label}] (susc={susc:.3f})--> "
+                f"{_binset(b)}"
             )
     return
 
@@ -649,9 +682,10 @@ def delimit_plot(mo):
     One directed community assembly graph per susceptibility sample,
     rendered with `iplotx` (matplotlib backend) via a `teeplot` loop.
     Communities are laid out left-to-right by the **number of resident
-    strains**, so assembly reads as growth from the `000` founder. Node
-    fill encodes the community via the color key; the number on each node is
-    the count of resident strains. The `000` founder is outlined **green**.
+    strains**, so assembly reads left-to-right as depth from the `000`
+    founder (every edge points rightward). Node fill encodes the community
+    via the color key; the number on each node is the count of resident
+    strains. The `000` founder is outlined **green**.
 
     **Node size** encodes the **even-split assembly flow**: a uniform
     assembly walk starts at the founder with unit weight and splits its
@@ -666,9 +700,11 @@ def delimit_plot(mo):
     hollow pair node it harbours. A terminal community that harbours *no*
     complement pair (an unresolved endpoint) is instead outlined **red**.
 
-    Each invasion edge is optionally labelled with the arrival-ordered
-    invading strain and its measured susceptibility (convergence edges into
-    the pair nodes are unlabelled). Two versions are saved per sample (tagged
+    Each edge is optionally labelled with the **taxon gained** (`+<strain>`,
+    the strain that established) and, in the extinction graphs, any **taxa
+    lost** (`-<strain>`, residents driven extinct by the addition), expressed
+    in the source community's arrival-order frame (convergence edges into the
+    pair nodes are unlabelled). Two versions are saved per graph (tagged
     `edge-labels=strain-susc` vs `edge-labels=none`).
     """
     )
@@ -676,15 +712,64 @@ def delimit_plot(mo):
 
 
 @app.cell
-def def_layout(defaultdict):
-    def layout_layered(nodes, np):
-        """x = community size (# resident strains); y spreads within a layer."""
-        cols = defaultdict(list)
-        for n in nodes:
-            cols[len(n)].append(n)
+def def_layout(defaultdict, deque):
+    def layout_dag(nodes, edges, np):
+        """Sugiyama-style layered layout: x = longest-path depth from the 000
+        founder, so every edge points rightward (no backward arrows even when
+        an extinction transition shrinks a community); y spreads a layer and
+        is barycenter-ordered against the previous layer to limit crossings.
+        Returns ``(coords, max_depth)``.
+        """
+        nodeset = set(nodes)
+        succ = defaultdict(list)
+        pred = defaultdict(list)
+        indeg = {n: 0 for n in nodeset}
+        for a, b in edges:
+            A, B = frozenset(a), frozenset(b)
+            if A in nodeset and B in nodeset:
+                succ[A].append(B)
+                pred[B].append(A)
+                indeg[B] += 1
+
+        # Kahn topological order, then longest-path depth from the sources.
+        ind = dict(indeg)
+        queue = deque(n for n in nodeset if ind[n] == 0)
+        topo = []
+        while queue:
+            u = queue.popleft()
+            topo.append(u)
+            for v in succ.get(u, []):
+                ind[v] -= 1
+                if ind[v] == 0:
+                    queue.append(v)
+        depth = {n: 0 for n in nodeset}
+        for u in topo:
+            for v in succ.get(u, []):
+                depth[v] = max(depth[v], depth[u] + 1)
+
+        layers = defaultdict(list)
+        for n in nodeset:
+            layers[depth[n]].append(n)
+        order = {
+            d: sorted(layers[d], key=lambda k: tuple(sorted(k)))
+            for d in layers
+        }
+        for _ in range(6):  # barycenter crossing-reduction sweeps
+            for d in sorted(order):
+                if d == 0:
+                    continue
+                prev_idx = {n: i for i, n in enumerate(order.get(d - 1, []))}
+                mid = len(order[d]) / 2.0
+
+                def _bary(n, _prev_idx=prev_idx, _mid=mid):
+                    ps = [_prev_idx[p] for p in pred[n] if p in _prev_idx]
+                    return sum(ps) / len(ps) if ps else _mid
+
+                order[d] = sorted(order[d], key=_bary)
+
         coords = {}
-        for x in sorted(cols):
-            layer = sorted(cols[x], key=lambda k: tuple(sorted(k)))
+        for d in order:
+            layer = order[d]
             m = len(layer)
             ys = (
                 np.linspace(-(m - 1) / 2.0, (m - 1) / 2.0, m)
@@ -692,10 +777,10 @@ def def_layout(defaultdict):
                 else [0.0]
             )
             for k, y in zip(layer, ys):
-                coords[k] = (float(x), float(y) * 1.6)
-        return coords
+                coords[k] = (float(d), float(y) * 1.7)
+        return coords, max(depth.values(), default=0)
 
-    return (layout_layered,)
+    return (layout_dag,)
 
 
 @app.cell
@@ -705,7 +790,7 @@ def def_plot(
     defaultdict,
     ig,
     iplotx,
-    layout_layered,
+    layout_dag,
     np,
     plt,
     sns,
@@ -744,11 +829,10 @@ def def_plot(
             comm_set, key=lambda k: (len(k), tuple(sorted(k)))
         )
 
-        # Layout: communities by size; complement-pair end nodes share the
-        # rightmost column (like the reference notebook's end nodes), ordered
-        # by the mean height of their source communities to limit crossings.
-        coords = layout_layered(comm_set, np)
-        maxsize = max((len(k) for k in comm_set), default=1)
+        # Layout: longest-path depth from the founder (edges point rightward);
+        # complement-pair end nodes share the rightmost column, ordered by the
+        # mean height of their source communities to limit crossings.
+        coords, maxdepth = layout_dag(comm_set, edges, np)
         src_y = defaultdict(list)
         for a, pk in pair_edges:
             src_y[pk].append(coords[frozenset(a)][1])
@@ -759,7 +843,7 @@ def def_plot(
         m = len(pairs)
         ys = np.linspace(-(m - 1) / 2.0, (m - 1) / 2.0, m) if m > 1 else [0.0]
         for pk, y in zip(pairs, ys):
-            coords[pk] = (float(maxsize + 1), float(y) * 1.8)
+            coords[pk] = (float(maxdepth + 1), float(y) * 1.8)
 
         nodes = communities + pairs  # community nodes first, pair nodes last
         idx = {_nid(k): i for i, k in enumerate(nodes)}
@@ -770,11 +854,11 @@ def def_plot(
         g = ig.Graph(directed=True)
         g.add_vertices(len(nodes))
         elist, ewidth, elabel = [], [], []
-        max_susc = max((s for _x, s in edges.values()), default=1.0)
-        for (a, b), (x, susc) in edges.items():
+        max_susc = max((s for _lbl, s in edges.values()), default=1.0)
+        for (a, b), (label, susc) in edges.items():
             elist.append((idx[a], idx[b]))
             ewidth.append(1.0 + 3.5 * (susc / max_susc))
-            elabel.append(f"{format(x, f'0{N_SITES}b')}\n{susc:.2f}")
+            elabel.append(label)
         for a, pk in pair_edges:  # convergence into the pair end node
             elist.append((idx[a], idx[pk]))
             ewidth.append(2.0)
@@ -838,7 +922,7 @@ def def_plot(
             )
         if pairs:
             _xlo, _xhi = ax.get_xlim()
-            ax.set_xlim(_xlo, max(_xhi, maxsize + 2.2))
+            ax.set_xlim(_xlo, max(_xhi, maxdepth + 2.2))
 
         # color-coded key: communities (filled) then complement-pair end
         # states (hollow, color-coded outline).

--- a/bindle/2026-07-14-community-assembly-invasion.py
+++ b/bindle/2026-07-14-community-assembly-invasion.py
@@ -351,10 +351,48 @@ def def_pairs(N_SITES):
 
 
 @app.cell
+def def_flow(defaultdict):
+    def assembly_flow(nodes, edges, pair_edges):
+        """Even-split assembly flow (visitation probability) per node.
+
+        A uniform assembly walk starts at the 000 founder with unit weight;
+        at every juncture the node's weight is split *evenly* among its
+        outgoing edges (invasions, or the convergence into a complement-pair
+        end node). A node's flow is the total weight reaching it --- the
+        probability the walk passes through it --- and the flow arriving at
+        the terminal / pair end nodes partitions the unit weight across
+        outcomes. Every invasion lengthens the community by one strain, so
+        processing community nodes in order of size is a valid topological
+        order (parents, being smaller, are always finished first).
+        """
+        founder = frozenset({0})
+        succ = defaultdict(list)
+        for a, b in edges:
+            succ[frozenset(a)].append(frozenset(b))
+        for a, pk in pair_edges:
+            succ[frozenset(a)].append(pk)
+
+        flow = {n: 0.0 for n in nodes}
+        for _a, pk in pair_edges:
+            flow[pk] = 0.0
+        flow[founder] = 1.0
+        for node in sorted(nodes, key=len):  # communities, small -> large
+            outs = succ.get(node, [])
+            if outs:
+                share = flow[node] / len(outs)
+                for target in outs:
+                    flow[target] += share
+        return flow
+
+    return (assembly_flow,)
+
+
+@app.cell
 def build_graphs(
     SAMPLE_INDICES,
     SUSC_THRESHOLD,
     WINDOW_ENDS,
+    assembly_flow,
     build_assembly_graph,
     community_pairs,
 ):
@@ -378,6 +416,7 @@ def build_graphs(
             for _pk in community_pairs(_n):
                 _pair_nodes.add(_pk)
                 _pair_edges.append((tuple(sorted(_n)), _pk))
+        _flow = assembly_flow(_nodes, _edges, _pair_edges)
         graphs[_i] = {
             "window_end": _w,
             "nodes": _nodes,
@@ -385,12 +424,16 @@ def build_graphs(
             "terminal": _terminal,
             "pair_nodes": _pair_nodes,
             "pair_edges": _pair_edges,
+            "flow": _flow,
         }
+        _pair_flow = {pk: _flow[pk] for pk in sorted(_pair_nodes)}
         print(
             f"sample {_i} (updates {_w - 1000 + 1}..{_w}): "
             f"{len(_nodes)} communities, {len(_edges)} invasions, "
             f"{len(_terminal)} terminal, "
-            f"{len(_pair_nodes)} complement-pair end states",
+            f"{len(_pair_nodes)} complement-pair end states; "
+            f"end-state flow: "
+            + ", ".join(f"{pk}={v:.2f}" for pk, v in _pair_flow.items()),
         )
     return (graphs,)
 
@@ -427,6 +470,13 @@ def delimit_plot(mo):
     strains**, so assembly reads as growth from the `000` founder. Node
     fill encodes the community via the color key; the number on each node is
     the count of resident strains. The `000` founder is outlined **green**.
+
+    **Node size** encodes the **even-split assembly flow**: a uniform
+    assembly walk starts at the founder with unit weight and splits its
+    weight *evenly* among the available invasions at each juncture, so a
+    node's area is proportional to the probability the walk passes through
+    it. The flow arriving at the terminal and complement-pair end nodes
+    partitions the unit weight across outcomes (printed above).
 
     Each **complement-pair end state** is drawn as a **hollow circle with a
     color-coded outline** (`000/111` green, the other pairs their own colors)
@@ -492,7 +542,15 @@ def def_plot(
         terminal = bundle["terminal"]
         pair_nodes = bundle["pair_nodes"]
         pair_edges = bundle["pair_edges"]
+        flow = bundle["flow"]
         founder = frozenset({0})
+
+        # Node size encodes the even-split assembly flow (visitation
+        # probability): area proportional to flow, so radius ~ sqrt(flow).
+        max_flow = max(flow.values()) if flow else 1.0
+
+        def vsize(k):
+            return 12.0 + 34.0 * np.sqrt(flow.get(k, 0.0) / max_flow)
 
         # Terminal communities that resolve to a complement pair (vs. an
         # unresolved "U"-like endpoint that harbours no pair). pair_edges
@@ -541,8 +599,9 @@ def def_plot(
             elabel.append("")
         g.add_edges(elist)
 
-        vface, vedge, vlw, vlabel = [], [], [], []
+        vsizes, vface, vedge, vlw, vlabel = [], [], [], [], []
         for k in nodes:
+            vsizes.append(vsize(k))
             if isinstance(k, str):  # complement-pair end node: hollow + coded
                 vface.append("white")
                 vedge.append(END_OUTLINE.get(k, "black"))
@@ -569,7 +628,7 @@ def def_plot(
             ax=ax,
             vertex_facecolor=vface,
             vertex_edgecolor=vedge,
-            vertex_size=32.0,
+            vertex_size=vsizes,
             vertex_linewidth=vlw,
             edge_linewidth=ewidth,
             edge_color="0.55",

--- a/bindle/2026-07-14-community-assembly-invasion.py
+++ b/bindle/2026-07-14-community-assembly-invasion.py
@@ -111,11 +111,27 @@ def configure_args(mo):
     # susceptibility windows).
     SAMPLES = str(_args.get("samples") or "1,2,3")
     SAMPLE_INDICES = [int(s) for s in SAMPLES.split(",") if s.strip()]
+    # Extinction-aware second graph set: the 1-based susceptibility sample to
+    # drive invasion (default 2 = the 2nd 1000-update window) and the
+    # extinction-time thresholds (updates) at which strains that have gone
+    # extinct in an assemblage's even-mix run are pruned before further
+    # additions.
+    EXT_SAMPLE = int(_args.get("extinction-sample") or 2)
+    EXT_STR = str(_args.get("extinction-thresholds") or "300,1000,3000,10000")
+    EXT_THRESHOLDS = [int(s) for s in EXT_STR.split(",") if s.strip()]
     print(
         f"args: SUSC_SLUG={SUSC_SLUG} STRAINLAST_SLUG={STRAINLAST_SLUG} "
-        f"R_THRESHOLD={R_THRESHOLD} SAMPLE_INDICES={SAMPLE_INDICES}",
+        f"R_THRESHOLD={R_THRESHOLD} SAMPLE_INDICES={SAMPLE_INDICES} "
+        f"EXT_SAMPLE={EXT_SAMPLE} EXT_THRESHOLDS={EXT_THRESHOLDS}",
     )
-    return R_THRESHOLD, STRAINLAST_SLUG, SAMPLE_INDICES, SUSC_SLUG
+    return (
+        EXT_SAMPLE,
+        EXT_THRESHOLDS,
+        R_THRESHOLD,
+        SAMPLE_INDICES,
+        STRAINLAST_SLUG,
+        SUSC_SLUG,
+    )
 
 
 @app.cell
@@ -154,12 +170,15 @@ def download_data(STRAINLAST_SLUG, SUSC_SLUG, download_parquet):
     print(
         f"n array_ids: {susc_df['array_id'].nunique()}  windows: {WINDOW_ENDS}"
     )
+    N_STEPS = int(susc_df["n_steps"].iloc[0])
     return (
         CONTACT_RATE,
         N_SITES,
+        N_STEPS,
         N_STRAINS,
         RECOVERY_RATE,
         WINDOW_ENDS,
+        strainlast_df,
         susc_df,
     )
 
@@ -305,7 +324,7 @@ def def_graph(N_SITES, deque, itertools, susc_map):
                     queue.append(child)
         return nodes, edges
 
-    return build_assembly_graph, canon
+    return bitmask, build_assembly_graph, canon, invaders
 
 
 @app.cell
@@ -347,36 +366,67 @@ def def_pairs(N_SITES):
         for i, pk in enumerate(PAIR_KEYS)
     }
     END_OUTLINE["000/111"] = "green"
-    return END_OUTLINE, community_pairs
+
+    def terminal_pair_nodes(terminal):
+        """Hollow complement-pair end nodes + convergence edges for terminals.
+
+        Each terminal community harbouring a complement pair converges into
+        the shared hollow pair node; branches ending on the same pair share
+        the node.
+        """
+        pair_nodes = set()
+        pair_edges = []
+        for n in terminal:
+            for pk in community_pairs(n):
+                pair_nodes.add(pk)
+                pair_edges.append((tuple(sorted(n)), pk))
+        return pair_nodes, pair_edges
+
+    return END_OUTLINE, community_pairs, terminal_pair_nodes
 
 
 @app.cell
-def def_flow(defaultdict):
+def def_flow(defaultdict, deque):
     def assembly_flow(nodes, edges, pair_edges):
         """Even-split assembly flow (visitation probability) per node.
 
         A uniform assembly walk starts at the 000 founder with unit weight;
         at every juncture the node's weight is split *evenly* among its
-        outgoing edges (invasions, or the convergence into a complement-pair
-        end node). A node's flow is the total weight reaching it --- the
-        probability the walk passes through it --- and the flow arriving at
-        the terminal / pair end nodes partitions the unit weight across
-        outcomes. Every invasion lengthens the community by one strain, so
-        processing community nodes in order of size is a valid topological
-        order (parents, being smaller, are always finished first).
+        outgoing edges (invasions, extinction transitions, or the convergence
+        into a complement-pair end node). A node's flow is the total weight
+        reaching it --- the probability the walk passes through it --- and the
+        flow arriving at the terminal / pair end nodes partitions the unit
+        weight across outcomes. The graph is a DAG (verified acyclic), so the
+        flow is propagated in a Kahn topological order --- necessary once
+        extinctions let a transition *shrink* a community rather than only
+        grow it.
         """
         founder = frozenset({0})
         succ = defaultdict(list)
+        all_nodes = set(nodes)
         for a, b in edges:
             succ[frozenset(a)].append(frozenset(b))
         for a, pk in pair_edges:
             succ[frozenset(a)].append(pk)
+            all_nodes.add(pk)
 
-        flow = {n: 0.0 for n in nodes}
-        for _a, pk in pair_edges:
-            flow[pk] = 0.0
+        indeg = {n: 0 for n in all_nodes}
+        for u in succ:
+            for v in succ[u]:
+                indeg[v] += 1
+        queue = deque(n for n in all_nodes if indeg[n] == 0)
+        topo = []
+        while queue:
+            u = queue.popleft()
+            topo.append(u)
+            for v in succ.get(u, []):
+                indeg[v] -= 1
+                if indeg[v] == 0:
+                    queue.append(v)
+
+        flow = {n: 0.0 for n in all_nodes}
         flow[founder] = 1.0
-        for node in sorted(nodes, key=len):  # communities, small -> large
+        for node in topo:
             outs = succ.get(node, [])
             if outs:
                 share = flow[node] / len(outs)
@@ -394,7 +444,7 @@ def build_graphs(
     WINDOW_ENDS,
     assembly_flow,
     build_assembly_graph,
-    community_pairs,
+    terminal_pair_nodes,
 ):
     # One assembly graph per requested susceptibility sample (1-based index
     # into WINDOW_ENDS -> the window's end update).
@@ -407,15 +457,7 @@ def build_graphs(
         _nodes, _edges = build_assembly_graph(_w, SUSC_THRESHOLD)
         _srcs = {e[0] for e in _edges}
         _terminal = {n for n in _nodes if tuple(sorted(n)) not in _srcs}
-        # Complement-pair end states: each terminal community that harbours a
-        # complement pair converges to a hollow, color-coded pair end node;
-        # branches converging to the same pair share that node.
-        _pair_nodes = set()
-        _pair_edges = []
-        for _n in _terminal:
-            for _pk in community_pairs(_n):
-                _pair_nodes.add(_pk)
-                _pair_edges.append((tuple(sorted(_n)), _pk))
+        _pair_nodes, _pair_edges = terminal_pair_nodes(_terminal)
         _flow = assembly_flow(_nodes, _edges, _pair_edges)
         graphs[_i] = {
             "window_end": _w,
@@ -436,6 +478,146 @@ def build_graphs(
             + ", ".join(f"{pk}={v:.2f}" for pk, v in _pair_flow.items()),
         )
     return (graphs,)
+
+
+@app.cell
+def build_last_map(N_STRAINS, np, strainlast_df):
+    # last_map[array_id] -> length-N_STRAINS vector of last_observed_update
+    # (-1 for strains never seeded; N_STEPS for strains that never went
+    # extinct in that community's even-mix seeded run).
+    def build_last_map(df):
+        out = {}
+        for aid, grp in df.groupby("array_id"):
+            vec = np.full(N_STRAINS, -1, dtype=int)
+            for strain, last in zip(
+                grp["strain"], grp["last_observed_update"]
+            ):
+                vec[int(strain)] = int(last)
+            out[int(aid)] = vec
+        return out
+
+    last_map = build_last_map(strainlast_df)
+    print(f"last_map entries: {len(last_map)}")
+    return (last_map,)
+
+
+@app.cell(hide_code=True)
+def delimit_extinction(mo):
+    mo.md(
+        r"""
+    ## Assembly with Extinctions
+
+    The graph above lets every strain that can invade persist forever. This
+    second set of graphs instead uses the **strain-persistence dataset**
+    (`last_observed_update` per strain, per even-mix-seeded community) to
+    prune strains that go **extinct**, and asks how the assembly endpoints
+    change with the extinction time horizon.
+
+    - **Invasion** is driven by the **2nd 1000-update susceptibility sample**
+      (`window_end_update = 2000`), exactly as above.
+    - **Extinction.** For an assemblage `C` (a community seeded as an even
+      mix, `array_id = bitmask(C)`), a strain has gone extinct *before* update
+      `T` when its `last_observed_update` in that run is `< T`. We keep only
+      the strains surviving to `T`.
+    - **Ordering.** *Extinctions occur before further additions*: from a
+      post-extinction community `C'` a single-mutation invader `x` is added,
+      then the even-mix outcome of `C' + {x}` immediately prunes every strain
+      not surviving to `T`, giving the next post-extinction community (which
+      may be **smaller** than `C'`). Invasions that leave the surviving set
+      unchanged are dropped.
+
+    One graph is drawn per extinction horizon `T` (updates) --- **300, 1000,
+    3000, 10000** --- with the same flow sizing, complement-pair end nodes,
+    and outcome-% annotations. As `T` grows, transient strains have more time
+    to be excluded, and the reachable endpoints collapse toward the stable
+    complement pairs.
+    """
+    )
+    return
+
+
+@app.cell
+def def_extinction_graph(bitmask, canon, deque, invaders, last_map):
+    def survivors(community, threshold):
+        """Strains of `community` still present at update >= threshold.
+
+        Read from the community's own even-mix seeded run (strainlast),
+        then re-canonicalized (extinction can leave a non-canonical subset).
+        """
+        last = last_map[bitmask(community)]
+        return canon(frozenset(g for g in community if last[g] >= threshold))
+
+    def build_extinction_graph(window, susc_threshold, ext_threshold):
+        """Assembly with extinctions resolved before each further addition.
+
+        BFS from the (post-extinction) 000 founder: from a post-extinction
+        community C' an admissible single-mutation invader (window
+        susceptibility > susc_threshold) is added, then the even-mix outcome
+        of C' + {x} prunes strains not surviving to ext_threshold, giving the
+        next post-extinction community. Self-transitions (surviving set
+        unchanged) and collapses to the empty set are dropped.
+        """
+        root = survivors(canon(frozenset({0})), ext_threshold)
+        nodes = {root}
+        edges = {}
+        queue = deque([root])
+        while queue:
+            community = queue.popleft()
+            if not community:
+                continue
+            for strain, susc in invaders(community, window):
+                if susc <= susc_threshold:
+                    continue
+                nxt = survivors(canon(community | {strain}), ext_threshold)
+                if nxt == community or not nxt:
+                    continue
+                edges[(tuple(sorted(community)), tuple(sorted(nxt)))] = (
+                    int(strain),
+                    susc,
+                )
+                if nxt not in nodes:
+                    nodes.add(nxt)
+                    queue.append(nxt)
+        return nodes, edges
+
+    return (build_extinction_graph,)
+
+
+@app.cell
+def build_ext_graphs(
+    EXT_SAMPLE,
+    EXT_THRESHOLDS,
+    SUSC_THRESHOLD,
+    WINDOW_ENDS,
+    assembly_flow,
+    build_extinction_graph,
+    terminal_pair_nodes,
+):
+    ext_window = WINDOW_ENDS[EXT_SAMPLE - 1]
+    ext_graphs = {}
+    for _T in EXT_THRESHOLDS:
+        _nodes, _edges = build_extinction_graph(ext_window, SUSC_THRESHOLD, _T)
+        _srcs = {e[0] for e in _edges}
+        _terminal = {n for n in _nodes if tuple(sorted(n)) not in _srcs}
+        _pair_nodes, _pair_edges = terminal_pair_nodes(_terminal)
+        _flow = assembly_flow(_nodes, _edges, _pair_edges)
+        ext_graphs[_T] = {
+            "window_end": ext_window,
+            "extinct_before": _T,
+            "nodes": _nodes,
+            "edges": _edges,
+            "terminal": _terminal,
+            "pair_nodes": _pair_nodes,
+            "pair_edges": _pair_edges,
+            "flow": _flow,
+        }
+        _pf = {pk: _flow[pk] for pk in sorted(_pair_nodes)}
+        print(
+            f"extinct<{_T}: {len(_nodes)} communities, {len(_edges)} "
+            f"transitions, {len(_terminal)} terminal; end-state flow: "
+            + ", ".join(f"{pk}={v:.2f}" for pk, v in _pf.items()),
+        )
+    return ext_graphs, ext_window
 
 
 @app.cell
@@ -640,6 +822,24 @@ def def_plot(
         )
         ax.margins(0.12)
 
+        # Annotate each hollow complement-pair end node with its outcome %
+        # (the even-split flow arriving there) just to its right.
+        for pk in pairs:
+            px, py = coords[pk]
+            ax.text(
+                px + 0.55,
+                py,
+                f"{flow.get(pk, 0.0) * 100:.0f}%",
+                va="center",
+                ha="left",
+                fontsize=10,
+                fontweight="bold",
+                color=END_OUTLINE.get(pk, "black"),
+            )
+        if pairs:
+            _xlo, _xhi = ax.get_xlim()
+            ax.set_xlim(_xlo, max(_xhi, maxsize + 2.2))
+
         # color-coded key: communities (filled) then complement-pair end
         # states (hollow, color-coded outline).
         legend_ax.axis("off")
@@ -730,13 +930,59 @@ def render_graphs(
                 teeplot_outexclude="viz",
                 teeplot_show=True,
                 teeplot_subdir=pathlib.Path(__file__).stem,
-            ) as (fig, (ax, lax)):
-                plot_graph(_bundle, ax, lax, edge_labels=_edge_labels)
-                fig.suptitle(
+            ) as (_fig, (_ax, _lax)):
+                plot_graph(_bundle, _ax, _lax, edge_labels=_edge_labels)
+                _fig.suptitle(
                     f"estimated community assembly by invasion  ---  "
                     f"susceptibility sample {_i} (updates {_w - 1000 + 1}"
                     f"..{_w}),  R0>{R_THRESHOLD:g} "
                     f"(susc>{SUSC_THRESHOLD:.3f})",
+                    fontsize=10,
+                )
+    return
+
+
+@app.cell
+def render_ext_graphs(
+    R_THRESHOLD,
+    ext_graphs,
+    ext_window,
+    pathlib,
+    plot_graph,
+    plt,
+    tp,
+):
+    # Loop over teeplot: one extinction-aware assembly graph per extinction
+    # horizon T, in two versions (edge labels vs bare arrows).
+    for _T in sorted(ext_graphs):
+        _bundle = ext_graphs[_T]
+
+        def _factory(**kwargs):
+            fig, (ax, lax) = plt.subplots(
+                1, 2, gridspec_kw={"width_ratios": [3, 1.2]}, **kwargs
+            )
+            return fig, (ax, lax)
+
+        for _edge_labels, _tag in [(True, "strain-susc"), (False, "none")]:
+            with tp.teed(
+                _factory,
+                figsize=(12, 7),
+                teeplot_outattrs={
+                    "a": "community-assembly-extinction-graph",
+                    "extinct-before": f"{_T}",
+                    "window-end": f"{ext_window}",
+                    "edge-labels": _tag,
+                },
+                teeplot_outexclude="viz",
+                teeplot_show=True,
+                teeplot_subdir=pathlib.Path(__file__).stem,
+            ) as (_fig, (_ax, _lax)):
+                plot_graph(_bundle, _ax, _lax, edge_labels=_edge_labels)
+                _fig.suptitle(
+                    f"community assembly with extinctions before {_T} "
+                    f"updates  ---  window-2 susceptibility "
+                    f"(updates {ext_window - 1000 + 1}..{ext_window}),  "
+                    f"R0>{R_THRESHOLD:g}",
                     fontsize=10,
                 )
     return

--- a/bindle/2026-07-14-community-assembly-invasion.py
+++ b/bindle/2026-07-14-community-assembly-invasion.py
@@ -1,0 +1,559 @@
+import marimo
+
+__generated_with = "0.23.2"
+app = marimo.App(width="full")
+
+
+@app.cell
+def import_std():
+    from collections import defaultdict, deque
+    import itertools
+    import pathlib
+
+    return defaultdict, deque, itertools, pathlib
+
+
+@app.cell
+def import_pkg():
+    # workaround: iplotx 1.7.x uses importlib.metadata without importing it
+    import importlib.metadata  # noqa: F401
+
+    import igraph as ig
+    import iplotx
+    import marimo as mo
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+    import requests
+    import seaborn as sns
+    from teeplot import teeplot as tp
+    from watermark import watermark
+
+    return ig, iplotx, mo, np, pd, plt, requests, sns, tp, watermark
+
+
+@app.cell(hide_code=True)
+def do_watermark(mo, watermark):
+    mo.md(
+        f"""
+    ```Text
+    {watermark(
+        current_date=True,
+        iso8601=True,
+        machine=True,
+        updated=True,
+        python=True,
+        iversions=True,
+        globals_=globals(),
+    )}
+    ```
+    """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def delimit_intro(mo):
+    mo.md(
+        r"""
+    # Estimated Community Assembly Graph from Invasibility
+
+    This notebook builds an **estimated community assembly graph** for the
+    3-site model (`N_SITES = 3`, 8 strains `000`..`111`) directly from the
+    **susceptibility snapshots** produced by the strain-persistence array
+    job (`2026-07-14-strain-persistence`). That job seeded every one of the
+    256 possible strain communities (one per `array_id`, its 8-bit binary
+    code selecting the seeded strains) and, every 1000 updates, recorded
+    the population's mean susceptibility to each of the 8 strains.
+
+    **Idea.** A community `C` (a set of resident strains) is *invasible* by
+    a rare strain `x` when `x`'s reproduction number while rare exceeds 1.
+    In this model that number is proportional to the mean population
+    susceptibility to `x` measured in the run that seeded `C`, so we read
+    invasibility straight off the susceptibility snapshot for
+    `array_id = bitmask(C)`. Starting from the `000` founder we repeatedly
+    let single-**mutation** neighbours of resident strains invade whenever
+    they clear the threshold, growing an assembly graph whose nodes are
+    communities and whose directed edges are invasions `C -> C + {x}`.
+
+    **Arrival-order relabeling (the same trick as the mutation-sweep
+    community-assembly notebook).** The three sites are exchangeable, so we
+    canonicalize each community by relabeling sites in **order of arrival**:
+    the site whose mutant allele arrives *first* becomes bit position 0, the
+    second-to-arrive bit position 1, the third bit position 2. This is
+    realized as the symmetry-minimal representative of the community, and it
+    collapses the 6 site-permutations of every community onto one canonical
+    node (e.g. all three single-mutant founders `001`/`010`/`100` become
+    `001`).
+
+    **Per-sample graphs.** Susceptibility drifts as herd immunity builds, so
+    invasibility --- and thus the assembly graph --- can change over time. We
+    loop over `teeplot` to draw one graph from the **first**, **second**, and
+    **third** 1000-update susceptibility sample (`window_end_update` = 1000,
+    2000, 3000).
+    """
+    )
+    return
+
+
+@app.cell
+def configure_args(mo):
+    # CLI args; defaults pull the susceptibility parquet that backs this
+    # notebook (the strainlast parquet is optional annotation).
+    _args = mo.cli_args()
+    SUSC_SLUG = str(_args.get("susc-slug") or "jhnyk")
+    STRAINLAST_SLUG = str(_args.get("strainlast-slug") or "9pebz")
+    # Invasion threshold expressed as an R0-while-rare cutoff (a strain
+    # invades when its estimated reproduction number while rare exceeds
+    # this). 1.0 is the epidemic threshold.
+    R_THRESHOLD = float(_args.get("r-threshold") or 1.0)
+    # 1-based sample indices to draw (first, second, third 1000-update
+    # susceptibility windows).
+    SAMPLES = str(_args.get("samples") or "1,2,3")
+    SAMPLE_INDICES = [int(s) for s in SAMPLES.split(",") if s.strip()]
+    print(
+        f"args: SUSC_SLUG={SUSC_SLUG} STRAINLAST_SLUG={STRAINLAST_SLUG} "
+        f"R_THRESHOLD={R_THRESHOLD} SAMPLE_INDICES={SAMPLE_INDICES}",
+    )
+    return R_THRESHOLD, STRAINLAST_SLUG, SAMPLE_INDICES, SUSC_SLUG
+
+
+@app.cell
+def def_download(pathlib, pd, requests):
+    def download_parquet(slug):
+        cache_path = pathlib.Path("/tmp") / slug
+        url = f"https://osf.io/{slug}/download"
+        if not cache_path.exists():
+            print(f"downloading {url} -> {cache_path}")
+            resp = requests.get(url, allow_redirects=True, timeout=180)
+            resp.raise_for_status()
+            cache_path.write_bytes(resp.content)
+        else:
+            print(f"reusing cached {cache_path}")
+        print(f"size: {cache_path.stat().st_size} bytes")
+        return pd.read_parquet(cache_path)
+
+    return (download_parquet,)
+
+
+@app.cell
+def download_data(STRAINLAST_SLUG, SUSC_SLUG, download_parquet):
+    susc_df = download_parquet(SUSC_SLUG)
+    strainlast_df = download_parquet(STRAINLAST_SLUG)
+
+    N_SITES = int(susc_df["n_sites"].iloc[0])
+    N_STRAINS = 1 << N_SITES
+    CONTACT_RATE = float(susc_df["contact_rate"].iloc[0])
+    RECOVERY_RATE = float(susc_df["recovery_rate"].iloc[0])
+    WINDOW_ENDS = sorted(int(w) for w in susc_df["window_end_update"].unique())
+    print(f"susc: {susc_df.shape}  strainlast: {strainlast_df.shape}")
+    print(
+        f"N_SITES={N_SITES} N_STRAINS={N_STRAINS} "
+        f"CONTACT_RATE={CONTACT_RATE} RECOVERY_RATE={RECOVERY_RATE}",
+    )
+    print(
+        f"n array_ids: {susc_df['array_id'].nunique()}  windows: {WINDOW_ENDS}"
+    )
+    return (
+        CONTACT_RATE,
+        N_SITES,
+        N_STRAINS,
+        RECOVERY_RATE,
+        WINDOW_ENDS,
+        susc_df,
+    )
+
+
+@app.cell
+def build_susc_map(N_STRAINS, np, susc_df):
+    # susc_map[(array_id, window_end_update)] -> length-N_STRAINS vector of
+    # mean susceptibility to each strain (genome integer) in that community.
+    def build_susc_map(df):
+        out = {}
+        for (aid, w), grp in df.groupby(["array_id", "window_end_update"]):
+            vec = np.zeros(N_STRAINS)
+            for strain, susc in zip(grp["strain"], grp["mean_susceptibility"]):
+                vec[int(strain)] = float(susc)
+            out[(int(aid), int(w))] = vec
+        return out
+
+    susc_map = build_susc_map(susc_df)
+    print(f"susc_map entries: {len(susc_map)} (256 communities x windows)")
+    return (susc_map,)
+
+
+@app.cell
+def def_susc_threshold(CONTACT_RATE, RECOVERY_RATE, R_THRESHOLD):
+    # A rare strain x invading community C has, per infectious host,
+    # ~CONTACT_RATE * susc new infections per update, and its deterministic
+    # infectious period contributes an R0 multiplier (1 - RECOVERY_RATE) /
+    # RECOVERY_RATE (the same multiplier the founder notebook uses: recovery
+    # runs after transmission within an update, so a primary infected at t
+    # transmits over sum_k (1-p)^k = (1-p)/p future updates). Hence
+    #   R0(x | C) = CONTACT_RATE * (1 - RECOVERY_RATE) / RECOVERY_RATE * susc
+    # and x invades when R0 > R_THRESHOLD, i.e. susc > SUSC_THRESHOLD.
+    R0_PER_SUSC = CONTACT_RATE * (1.0 - RECOVERY_RATE) / RECOVERY_RATE
+    SUSC_THRESHOLD = R_THRESHOLD / R0_PER_SUSC
+    print(
+        f"R0 per unit susceptibility = {R0_PER_SUSC:.4f}; "
+        f"invade when susc > {SUSC_THRESHOLD:.4f} "
+        f"(R0 > {R_THRESHOLD})",
+    )
+    return R0_PER_SUSC, SUSC_THRESHOLD
+
+
+@app.cell(hide_code=True)
+def delimit_build(mo):
+    mo.md(
+        r"""
+    ## Build the Invasion Assembly Graph
+
+    **Canonicalization.** `canon(community)` relabels sites by arrival order,
+    implemented as the lexicographically-minimal genome set over the
+    `N_SITES!` site permutations. Because every site has identical
+    parameters, symmetric communities collapse to one canonical node and
+    the founder `000` and all-ones `111` are fixed points.
+
+    **Invasion step.** From canonical community `C` (with
+    `array_id = bitmask(C)`) the candidate invaders are the single-mutation
+    neighbours of resident strains that are not already present ---
+    `x = r ^ (1 << s)` for a resident `r` and site `s`. Strain `x` invades
+    when its measured susceptibility in `C`'s run exceeds `SUSC_THRESHOLD`;
+    the resulting community `canon(C + {x})` is the edge target.
+
+    **Assembly.** A breadth-first sweep from the `000` founder applies the
+    invasion step until no new community appears, yielding the directed
+    assembly graph for that susceptibility sample. Communities with no
+    admissible invader are **terminal** (uninvadable) assembly endpoints.
+    """
+    )
+    return
+
+
+@app.cell
+def def_graph(N_SITES, deque, itertools, susc_map):
+    _PERMS = list(itertools.permutations(range(N_SITES)))
+
+    def _permute_genome(g, perm):
+        return sum((1 << perm[i]) for i in range(N_SITES) if (g >> i) & 1)
+
+    def canon(community):
+        """Arrival-order canonical form: symmetry-minimal genome set.
+
+        Relabels sites so the first-arriving site is bit 0, etc. --- the
+        lexicographically smallest genome frozenset over all site
+        permutations. Symmetric communities share one canonical node.
+        """
+        best_key = None
+        best = None
+        for perm in _PERMS:
+            mapped = frozenset(_permute_genome(g, perm) for g in community)
+            key = tuple(sorted(mapped))
+            if best_key is None or key < best_key:
+                best_key, best = key, mapped
+        return best
+
+    def bitmask(community):
+        m = 0
+        for g in community:
+            m |= 1 << g
+        return int(m)
+
+    def invaders(community, window):
+        """(strain, susceptibility) for admissible single-mutation invaders.
+
+        Candidates are Hamming-1 neighbours of resident strains not already
+        present; susceptibility is read from the community's own run
+        (array_id = bitmask). Threshold comparison is left to the caller.
+        """
+        susc = susc_map[(bitmask(community), int(window))]
+        cands = {
+            r ^ (1 << s) for r in community for s in range(N_SITES)
+        } - set(community)
+        return sorted((x, float(susc[x])) for x in cands)
+
+    def build_assembly_graph(window, susc_threshold):
+        """BFS from the 000 founder; returns (nodes, edges).
+
+        nodes: set of canonical community frozensets.
+        edges: dict (src_tuple, dst_tuple) -> (invader_strain, susc).
+        """
+        root = canon(frozenset({0}))
+        nodes = {root}
+        edges = {}
+        queue = deque([root])
+        while queue:
+            community = queue.popleft()
+            for strain, susc in invaders(community, window):
+                if susc <= susc_threshold:
+                    continue
+                child = canon(community | {strain})
+                edges[(tuple(sorted(community)), tuple(sorted(child)))] = (
+                    int(strain),
+                    susc,
+                )
+                if child not in nodes:
+                    nodes.add(child)
+                    queue.append(child)
+        return nodes, edges
+
+    return build_assembly_graph, canon
+
+
+@app.cell
+def build_graphs(
+    SAMPLE_INDICES, SUSC_THRESHOLD, WINDOW_ENDS, build_assembly_graph
+):
+    # One assembly graph per requested susceptibility sample (1-based index
+    # into WINDOW_ENDS -> the window's end update).
+    graphs = {}
+    for _i in SAMPLE_INDICES:
+        if not 1 <= _i <= len(WINDOW_ENDS):
+            print(f"skipping sample {_i}: out of range 1..{len(WINDOW_ENDS)}")
+            continue
+        _w = WINDOW_ENDS[_i - 1]
+        _nodes, _edges = build_assembly_graph(_w, SUSC_THRESHOLD)
+        _srcs = {e[0] for e in _edges}
+        _terminal = {n for n in _nodes if tuple(sorted(n)) not in _srcs}
+        graphs[_i] = {
+            "window_end": _w,
+            "nodes": _nodes,
+            "edges": _edges,
+            "terminal": _terminal,
+        }
+        print(
+            f"sample {_i} (updates {_w - 1000 + 1}..{_w}): "
+            f"{len(_nodes)} communities, {len(_edges)} invasions, "
+            f"{len(_terminal)} terminal",
+        )
+    return (graphs,)
+
+
+@app.cell
+def peek_graph(N_SITES, graphs):
+    # Text dump of the first requested sample's assembly graph.
+    def _binset(t):
+        return "{" + ",".join(format(g, f"0{N_SITES}b") for g in t) + "}"
+
+    if graphs:
+        _i = sorted(graphs)[0]
+        _g = graphs[_i]
+        print(f"sample {_i} (window end {_g['window_end']}):")
+        for (a, b), (x, susc) in sorted(
+            _g["edges"].items(), key=lambda kv: (len(kv[0][0]), kv[0])
+        ):
+            print(
+                f"  {_binset(a)} --{format(x, f'0{N_SITES}b')}"
+                f" (susc={susc:.3f})--> {_binset(b)}"
+            )
+    return
+
+
+@app.cell(hide_code=True)
+def delimit_plot(mo):
+    mo.md(
+        """
+    ## Plot the Assembly Graphs
+
+    One directed community assembly graph per susceptibility sample,
+    rendered with `iplotx` (matplotlib backend) via a `teeplot` loop.
+    Communities are laid out left-to-right by the **number of resident
+    strains**, so assembly reads as growth from the `000` founder. Node
+    fill encodes the community via the color key; the number on each node is
+    the count of resident strains. **Terminal (uninvadable) communities** ---
+    assembly endpoints with no admissible invader --- are outlined **red**;
+    the `000` founder is outlined **green**. Each edge is an invasion,
+    optionally labelled with the arrival-ordered invading strain and its
+    measured susceptibility. Two versions are saved per sample (tagged
+    `edge-labels=strain-susc` vs `edge-labels=none`).
+    """
+    )
+    return
+
+
+@app.cell
+def def_layout(defaultdict):
+    def layout_layered(nodes, np):
+        """x = community size (# resident strains); y spreads within a layer."""
+        cols = defaultdict(list)
+        for n in nodes:
+            cols[len(n)].append(n)
+        coords = {}
+        for x in sorted(cols):
+            layer = sorted(cols[x], key=lambda k: tuple(sorted(k)))
+            m = len(layer)
+            ys = (
+                np.linspace(-(m - 1) / 2.0, (m - 1) / 2.0, m)
+                if m > 1
+                else [0.0]
+            )
+            for k, y in zip(layer, ys):
+                coords[k] = (float(x), float(y) * 1.6)
+        return coords
+
+    return (layout_layered,)
+
+
+@app.cell
+def def_plot(
+    N_SITES,
+    ig,
+    iplotx,
+    layout_layered,
+    np,
+    plt,
+    sns,
+):
+    def _binset(community):
+        return ", ".join(format(g, f"0{N_SITES}b") for g in sorted(community))
+
+    def plot_graph(bundle, ax, legend_ax, palette="husl", edge_labels=True):
+        nodes_set = bundle["nodes"]
+        edges = bundle["edges"]
+        terminal = bundle["terminal"]
+        founder = frozenset({0})
+
+        nodes = sorted(nodes_set, key=lambda k: (len(k), tuple(sorted(k))))
+        idx = {tuple(sorted(k)): i for i, k in enumerate(nodes)}
+        coords = layout_layered(nodes_set, np)
+
+        colors = sns.color_palette(palette, n_colors=max(3, len(nodes)))
+        colormap = {k: colors[i] for i, k in enumerate(nodes)}
+
+        g = ig.Graph(directed=True)
+        g.add_vertices(len(nodes))
+        elist, ewidth, elabel = [], [], []
+        max_susc = max((s for _x, s in edges.values()), default=1.0)
+        for (a, b), (x, susc) in edges.items():
+            elist.append((idx[a], idx[b]))
+            ewidth.append(1.0 + 3.5 * (susc / max_susc))
+            elabel.append(f"{format(x, f'0{N_SITES}b')}\n{susc:.2f}")
+        g.add_edges(elist)
+
+        vface, vedge, vlw, vlabel = [], [], [], []
+        for k in nodes:
+            vface.append(colormap[k])
+            if k == founder:
+                vedge.append("green")
+                vlw.append(3.0)
+            elif k in terminal:
+                vedge.append("red")
+                vlw.append(3.0)
+            else:
+                vedge.append("black")
+                vlw.append(1.0)
+            vlabel.append(str(len(k)))
+
+        iplotx.network(
+            g,
+            layout=[coords[k] for k in nodes],
+            vertex_labels=vlabel,
+            edge_labels=(elabel if edge_labels else None),
+            ax=ax,
+            vertex_facecolor=vface,
+            vertex_edgecolor=vedge,
+            vertex_size=32.0,
+            vertex_linewidth=vlw,
+            edge_linewidth=ewidth,
+            edge_color="0.55",
+            vertex_label_color="black",
+            vertex_label_size=9,
+            edge_label_size=6,
+            edge_label_rotate=False,
+            show=False,
+        )
+        ax.margins(0.12)
+
+        # color-coded key: community (present strains); founder/terminal noted
+        legend_ax.axis("off")
+        handles, labels = [], []
+        for k in nodes:
+            outline = (
+                "green"
+                if k == founder
+                else ("red" if k in terminal else "black")
+            )
+            handles.append(
+                plt.Line2D(
+                    [0],
+                    [0],
+                    marker="o",
+                    color="w",
+                    markerfacecolor=colormap[k],
+                    markeredgecolor=outline,
+                    markeredgewidth=1.8 if outline != "black" else 0.6,
+                    markersize=9,
+                )
+            )
+            suffix = (
+                "  (founder)"
+                if k == founder
+                else ("  (terminal)" if k in terminal else "")
+            )
+            labels.append(f"{{{_binset(k)}}}{suffix}")
+        legend_ax.legend(
+            handles,
+            labels,
+            loc="center left",
+            fontsize=6.5,
+            title="community (resident strains)",
+            title_fontsize=8,
+            ncol=1 if len(nodes) <= 16 else 2,
+            frameon=False,
+            handletextpad=0.4,
+            labelspacing=0.3,
+            borderaxespad=0.0,
+        )
+
+    return (plot_graph,)
+
+
+@app.cell
+def render_graphs(
+    R_THRESHOLD,
+    SUSC_THRESHOLD,
+    graphs,
+    pathlib,
+    plot_graph,
+    plt,
+    tp,
+):
+    # Loop over teeplot: one assembly graph per susceptibility sample, in two
+    # versions (edge labels vs bare arrows), tagged apart via teeplot_outattrs.
+    for _i in sorted(graphs):
+        _bundle = graphs[_i]
+        _w = _bundle["window_end"]
+
+        def _factory(**kwargs):
+            fig, (ax, lax) = plt.subplots(
+                1, 2, gridspec_kw={"width_ratios": [3, 1.2]}, **kwargs
+            )
+            return fig, (ax, lax)
+
+        for _edge_labels, _tag in [(True, "strain-susc"), (False, "none")]:
+            with tp.teed(
+                _factory,
+                figsize=(12, 7),
+                teeplot_outattrs={
+                    "a": "community-assembly-invasion-graph",
+                    "sample": f"{_i}",
+                    "window-end": f"{_w}",
+                    "edge-labels": _tag,
+                },
+                teeplot_outexclude="viz",
+                teeplot_show=True,
+                teeplot_subdir=pathlib.Path(__file__).stem,
+            ) as (fig, (ax, lax)):
+                plot_graph(_bundle, ax, lax, edge_labels=_edge_labels)
+                fig.suptitle(
+                    f"estimated community assembly by invasion  ---  "
+                    f"susceptibility sample {_i} (updates {_w - 1000 + 1}"
+                    f"..{_w}),  R0>{R_THRESHOLD:g} "
+                    f"(susc>{SUSC_THRESHOLD:.3f})",
+                    fontsize=10,
+                )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/bindle/2026-07-14-community-assembly-invasion.py
+++ b/bindle/2026-07-14-community-assembly-invasion.py
@@ -288,6 +288,31 @@ def def_graph(N_SITES, deque, itertools, susc_map):
         """
         return canon_perm(community)[0]
 
+    def edge_change_label(community, survivors):
+        """Label a transition from canonical ``community`` to
+        ``canon(survivors)``; returns ``(label, child)``.
+
+        ``survivors`` is the surviving genome set in the *parent* frame. The
+        **gained** taxon is relabelled into the **child** frame --- i.e. the
+        arrival-order label the newly established strain carries in the
+        community it joins --- so a fresh site read as ``+001`` then ``+010``
+        then ``+100`` down a path rather than an arbitrary source-frame
+        representative of the symmetric invaders. **Lost** taxa keep their
+        parent-frame labels (they no longer exist in the child). Each taxon is
+        thus labelled in the community where it is actually present.
+        """
+        child, perm = canon_perm(survivors)
+        resident = set(community)
+        gained = sorted(
+            _permute_genome(g, perm) for g in survivors if g not in resident
+        )
+        lost = sorted(resident - set(survivors))
+        label = " ".join(
+            [f"+{format(g, f'0{N_SITES}b')}" for g in gained]
+            + [f"-{format(g, f'0{N_SITES}b')}" for g in lost]
+        )
+        return label, child
+
     def bitmask(community):
         m = 0
         for g in community:
@@ -312,7 +337,7 @@ def def_graph(N_SITES, deque, itertools, susc_map):
 
         nodes: set of canonical community frozensets.
         edges: dict (src_tuple, dst_tuple) -> (label, susc); every edge is a
-        pure gain, labelled ``+<invader>`` in the source frame.
+        pure gain, labelled ``+<strain>`` in the child (arrival-order) frame.
         """
         root = canon(frozenset({0}))
         nodes = {root}
@@ -323,8 +348,9 @@ def def_graph(N_SITES, deque, itertools, susc_map):
             for strain, susc in invaders(community, window):
                 if susc <= susc_threshold:
                     continue
-                child = canon(community | {strain})
-                label = f"+{format(int(strain), f'0{N_SITES}b')}"
+                label, child = edge_change_label(
+                    community, frozenset(community | {strain})
+                )
                 edges[(tuple(sorted(community)), tuple(sorted(child)))] = (
                     label,
                     susc,
@@ -334,7 +360,14 @@ def def_graph(N_SITES, deque, itertools, susc_map):
                     queue.append(child)
         return nodes, edges
 
-    return bitmask, build_assembly_graph, canon, canon_perm, invaders
+    return (
+        bitmask,
+        build_assembly_graph,
+        canon,
+        canon_perm,
+        edge_change_label,
+        invaders,
+    )
 
 
 @app.cell
@@ -548,7 +581,14 @@ def delimit_extinction(mo):
 
 @app.cell
 def def_extinction_graph(
-    N_SITES, bitmask, canon, canon_perm, deque, invaders, last_map
+    N_SITES,
+    bitmask,
+    canon,
+    canon_perm,
+    deque,
+    edge_change_label,
+    invaders,
+    last_map,
 ):
     def _survivors_in_frame(community, threshold):
         """Members of `community` surviving to `threshold`, kept in the input
@@ -576,11 +616,11 @@ def def_extinction_graph(
         community C' an admissible single-mutation invader (window
         susceptibility > susc_threshold) is added, then the even-mix outcome
         of C' + {x} prunes strains not surviving to ext_threshold, giving the
-        next post-extinction community. Each edge is labelled with the
-        *parent-frame* net change --- ``+<invader>`` for the strain that
-        established plus ``-<resident>`` for each resident it drove extinct.
-        Self-transitions (surviving set unchanged) and collapses to the empty
-        set are dropped.
+        next post-extinction community. Each edge is labelled with the net
+        change --- ``+<strain>`` (child frame) for the taxon that established
+        plus ``-<resident>`` (parent frame) for each resident it drove
+        extinct. Self-transitions (surviving set unchanged) and collapses to
+        the empty set are dropped.
         """
         root = survivors(canon(frozenset({0})), ext_threshold)
         nodes = {root}
@@ -595,15 +635,9 @@ def def_extinction_graph(
                     continue
                 assembled = community | {strain}
                 surv = _survivors_in_frame(assembled, ext_threshold)
-                nxt = canon(surv)
+                label, nxt = edge_change_label(community, surv)
                 if nxt == community or not nxt:
                     continue
-                gained = sorted(surv - community)
-                lost = sorted(community - surv)
-                label = " ".join(
-                    [f"+{format(g, f'0{N_SITES}b')}" for g in gained]
-                    + [f"-{format(g, f'0{N_SITES}b')}" for g in lost]
-                )
                 edges[(tuple(sorted(community)), tuple(sorted(nxt)))] = (
                     label,
                     susc,

--- a/bindle/2026-07-14-community-assembly-invasion.py
+++ b/bindle/2026-07-14-community-assembly-invasion.py
@@ -225,6 +225,14 @@ def delimit_build(mo):
     invasion step until no new community appears, yielding the directed
     assembly graph for that susceptibility sample. Communities with no
     admissible invader are **terminal** (uninvadable) assembly endpoints.
+
+    **Complement-pair end states.** A terminal community that harbours a
+    strain and its bitwise complement (`a` and `a ^ 111`) is a *converged*
+    end state --- the complement pair partitions the immune landscape and
+    stably coexists. Each such terminal converges to a **complement-pair end
+    node** (`000/111`, `001/110`, `010/101`, `011/100`); branches ending on
+    the same pair share that node. Complementation commutes with the
+    arrival-order relabeling, so the pairs are canonical too.
     """
     )
     return
@@ -301,8 +309,54 @@ def def_graph(N_SITES, deque, itertools, susc_map):
 
 
 @app.cell
+def def_pairs(N_SITES):
+    FULL = (1 << N_SITES) - 1  # all-ones strain (complement of the founder)
+
+    def binstr(g):
+        return format(g, f"0{N_SITES}b")
+
+    def pair_key(a, b):
+        """Canonical label for a complement pair, e.g. 000/111."""
+        lo, hi = sorted((a, b))
+        return f"{binstr(lo)}/{binstr(hi)}"
+
+    def community_pairs(community):
+        """Complement pairs {a, a ^ FULL} with both members present.
+
+        A terminal community harbouring such a pair is a *converged*
+        assembly end state: a strain and its bitwise complement stably
+        coexisting (they partition the immune landscape). Complementation
+        commutes with the arrival-order relabeling, so canonical communities
+        keep canonical pairs.
+        """
+        return sorted(
+            pair_key(a, a ^ FULL)
+            for a in community
+            if (a ^ FULL) in community and a <= (a ^ FULL)
+        )
+
+    # Outline colors for the complement-pair end states, mirroring the
+    # mutation-sweep community-assembly notebook: 000/111 (founder + all-ones)
+    # green, the remaining pairs each their own color.
+    PAIR_KEYS = [
+        pair_key(s, s ^ FULL) for s in range(FULL + 1) if s <= s ^ FULL
+    ]
+    _pair_palette = ["green", "#1f77b4", "#ff7f0e", "#9467bd", "#8c564b"]
+    END_OUTLINE = {
+        pk: _pair_palette[i % len(_pair_palette)]
+        for i, pk in enumerate(PAIR_KEYS)
+    }
+    END_OUTLINE["000/111"] = "green"
+    return END_OUTLINE, community_pairs
+
+
+@app.cell
 def build_graphs(
-    SAMPLE_INDICES, SUSC_THRESHOLD, WINDOW_ENDS, build_assembly_graph
+    SAMPLE_INDICES,
+    SUSC_THRESHOLD,
+    WINDOW_ENDS,
+    build_assembly_graph,
+    community_pairs,
 ):
     # One assembly graph per requested susceptibility sample (1-based index
     # into WINDOW_ENDS -> the window's end update).
@@ -315,16 +369,28 @@ def build_graphs(
         _nodes, _edges = build_assembly_graph(_w, SUSC_THRESHOLD)
         _srcs = {e[0] for e in _edges}
         _terminal = {n for n in _nodes if tuple(sorted(n)) not in _srcs}
+        # Complement-pair end states: each terminal community that harbours a
+        # complement pair converges to a hollow, color-coded pair end node;
+        # branches converging to the same pair share that node.
+        _pair_nodes = set()
+        _pair_edges = []
+        for _n in _terminal:
+            for _pk in community_pairs(_n):
+                _pair_nodes.add(_pk)
+                _pair_edges.append((tuple(sorted(_n)), _pk))
         graphs[_i] = {
             "window_end": _w,
             "nodes": _nodes,
             "edges": _edges,
             "terminal": _terminal,
+            "pair_nodes": _pair_nodes,
+            "pair_edges": _pair_edges,
         }
         print(
             f"sample {_i} (updates {_w - 1000 + 1}..{_w}): "
             f"{len(_nodes)} communities, {len(_edges)} invasions, "
-            f"{len(_terminal)} terminal",
+            f"{len(_terminal)} terminal, "
+            f"{len(_pair_nodes)} complement-pair end states",
         )
     return (graphs,)
 
@@ -360,11 +426,17 @@ def delimit_plot(mo):
     Communities are laid out left-to-right by the **number of resident
     strains**, so assembly reads as growth from the `000` founder. Node
     fill encodes the community via the color key; the number on each node is
-    the count of resident strains. **Terminal (uninvadable) communities** ---
-    assembly endpoints with no admissible invader --- are outlined **red**;
-    the `000` founder is outlined **green**. Each edge is an invasion,
-    optionally labelled with the arrival-ordered invading strain and its
-    measured susceptibility. Two versions are saved per sample (tagged
+    the count of resident strains. The `000` founder is outlined **green**.
+
+    Each **complement-pair end state** is drawn as a **hollow circle with a
+    color-coded outline** (`000/111` green, the other pairs their own colors)
+    sharing the rightmost column; a terminal community converges into the
+    hollow pair node it harbours. A terminal community that harbours *no*
+    complement pair (an unresolved endpoint) is instead outlined **red**.
+
+    Each invasion edge is optionally labelled with the arrival-ordered
+    invading strain and its measured susceptibility (convergence edges into
+    the pair nodes are unlabelled). Two versions are saved per sample (tagged
     `edge-labels=strain-susc` vs `edge-labels=none`).
     """
     )
@@ -396,7 +468,9 @@ def def_layout(defaultdict):
 
 @app.cell
 def def_plot(
+    END_OUTLINE,
     N_SITES,
+    defaultdict,
     ig,
     iplotx,
     layout_layered,
@@ -407,18 +481,51 @@ def def_plot(
     def _binset(community):
         return ", ".join(format(g, f"0{N_SITES}b") for g in sorted(community))
 
+    def _nid(k):
+        # Node id: sorted-genome tuple for a community, the string for a
+        # complement-pair end node.
+        return tuple(sorted(k)) if isinstance(k, frozenset) else k
+
     def plot_graph(bundle, ax, legend_ax, palette="husl", edge_labels=True):
-        nodes_set = bundle["nodes"]
+        comm_set = bundle["nodes"]
         edges = bundle["edges"]
         terminal = bundle["terminal"]
+        pair_nodes = bundle["pair_nodes"]
+        pair_edges = bundle["pair_edges"]
         founder = frozenset({0})
 
-        nodes = sorted(nodes_set, key=lambda k: (len(k), tuple(sorted(k))))
-        idx = {tuple(sorted(k)): i for i, k in enumerate(nodes)}
-        coords = layout_layered(nodes_set, np)
+        # Terminal communities that resolve to a complement pair (vs. an
+        # unresolved "U"-like endpoint that harbours no pair). pair_edges
+        # store sorted-tuple sources, so rebuild as frozensets to match the
+        # community node keys.
+        resolved = {frozenset(a) for a, _pk in pair_edges}
 
-        colors = sns.color_palette(palette, n_colors=max(3, len(nodes)))
-        colormap = {k: colors[i] for i, k in enumerate(nodes)}
+        communities = sorted(
+            comm_set, key=lambda k: (len(k), tuple(sorted(k)))
+        )
+
+        # Layout: communities by size; complement-pair end nodes share the
+        # rightmost column (like the reference notebook's end nodes), ordered
+        # by the mean height of their source communities to limit crossings.
+        coords = layout_layered(comm_set, np)
+        maxsize = max((len(k) for k in comm_set), default=1)
+        src_y = defaultdict(list)
+        for a, pk in pair_edges:
+            src_y[pk].append(coords[frozenset(a)][1])
+        pairs = sorted(
+            pair_nodes,
+            key=lambda pk: sum(src_y[pk]) / max(len(src_y[pk]), 1),
+        )
+        m = len(pairs)
+        ys = np.linspace(-(m - 1) / 2.0, (m - 1) / 2.0, m) if m > 1 else [0.0]
+        for pk, y in zip(pairs, ys):
+            coords[pk] = (float(maxsize + 1), float(y) * 1.8)
+
+        nodes = communities + pairs  # community nodes first, pair nodes last
+        idx = {_nid(k): i for i, k in enumerate(nodes)}
+
+        colors = sns.color_palette(palette, n_colors=max(3, len(communities)))
+        colormap = {k: colors[i] for i, k in enumerate(communities)}
 
         g = ig.Graph(directed=True)
         g.add_vertices(len(nodes))
@@ -428,21 +535,31 @@ def def_plot(
             elist.append((idx[a], idx[b]))
             ewidth.append(1.0 + 3.5 * (susc / max_susc))
             elabel.append(f"{format(x, f'0{N_SITES}b')}\n{susc:.2f}")
+        for a, pk in pair_edges:  # convergence into the pair end node
+            elist.append((idx[a], idx[pk]))
+            ewidth.append(2.0)
+            elabel.append("")
         g.add_edges(elist)
 
         vface, vedge, vlw, vlabel = [], [], [], []
         for k in nodes:
-            vface.append(colormap[k])
-            if k == founder:
-                vedge.append("green")
+            if isinstance(k, str):  # complement-pair end node: hollow + coded
+                vface.append("white")
+                vedge.append(END_OUTLINE.get(k, "black"))
                 vlw.append(3.0)
-            elif k in terminal:
-                vedge.append("red")
-                vlw.append(3.0)
+                vlabel.append("2")
             else:
-                vedge.append("black")
-                vlw.append(1.0)
-            vlabel.append(str(len(k)))
+                vface.append(colormap[k])
+                if k == founder:
+                    vedge.append("green")
+                    vlw.append(3.0)
+                elif k in terminal and k not in resolved:
+                    vedge.append("red")  # unresolved endpoint (no pair)
+                    vlw.append(3.0)
+                else:
+                    vedge.append("black")
+                    vlw.append(1.0)
+                vlabel.append(str(len(k)))
 
         iplotx.network(
             g,
@@ -464,15 +581,17 @@ def def_plot(
         )
         ax.margins(0.12)
 
-        # color-coded key: community (present strains); founder/terminal noted
+        # color-coded key: communities (filled) then complement-pair end
+        # states (hollow, color-coded outline).
         legend_ax.axis("off")
         handles, labels = [], []
-        for k in nodes:
-            outline = (
-                "green"
-                if k == founder
-                else ("red" if k in terminal else "black")
-            )
+        for k in communities:
+            if k == founder:
+                outline, mew, suffix = "green", 1.8, "  (founder)"
+            elif k in terminal and k not in resolved:
+                outline, mew, suffix = "red", 1.8, "  (terminal, no pair)"
+            else:
+                outline, mew, suffix = "black", 0.6, ""
             handles.append(
                 plt.Line2D(
                     [0],
@@ -481,16 +600,25 @@ def def_plot(
                     color="w",
                     markerfacecolor=colormap[k],
                     markeredgecolor=outline,
-                    markeredgewidth=1.8 if outline != "black" else 0.6,
+                    markeredgewidth=mew,
                     markersize=9,
                 )
             )
-            suffix = (
-                "  (founder)"
-                if k == founder
-                else ("  (terminal)" if k in terminal else "")
-            )
             labels.append(f"{{{_binset(k)}}}{suffix}")
+        for pk in pairs:
+            handles.append(
+                plt.Line2D(
+                    [0],
+                    [0],
+                    marker="o",
+                    color="w",
+                    markerfacecolor="white",
+                    markeredgecolor=END_OUTLINE.get(pk, "black"),
+                    markeredgewidth=2.0,
+                    markersize=9,
+                )
+            )
+            labels.append(f"{pk}  (complement-pair end state)")
         legend_ax.legend(
             handles,
             labels,
@@ -498,7 +626,7 @@ def def_plot(
             fontsize=6.5,
             title="community (resident strains)",
             title_fontsize=8,
-            ncol=1 if len(nodes) <= 16 else 2,
+            ncol=1 if len(handles) <= 16 else 2,
             frameon=False,
             handletextpad=0.4,
             labelspacing=0.3,

--- a/bindle/2026-07-14-strain-persistence.py
+++ b/bindle/2026-07-14-strain-persistence.py
@@ -74,11 +74,19 @@ def configure_args(mo):
     # the unconfigured run still exercises the seed / observe / save path
     # rather than the empty ARRAY_ID=0 community.
     _args = mo.cli_args()
-    ARRAY_ID = int(_args.get("array-id") or 3)
-    SEED = int(_args.get("seed") or 1)
-    POP_SIZE = int(_args.get("pop-size") or 100_000)
-    N_STEPS = int(_args.get("n-steps") or 1_200)
-    SEED_COUNT_PER_STRAIN = int(_args.get("seed-count-per-strain") or 10)
+
+    def _arg_int(name, default):
+        # Explicit None check, NOT `value or default`: array_id == 0 (the
+        # empty community) is a valid, load-bearing value that the truthy
+        # `or` idiom would silently rewrite to the default.
+        value = _args.get(name)
+        return default if value is None else int(value)
+
+    ARRAY_ID = _arg_int("array-id", 3)
+    SEED = _arg_int("seed", 1)
+    POP_SIZE = _arg_int("pop-size", 100_000)
+    N_STEPS = _arg_int("n-steps", 1_200)
+    SEED_COUNT_PER_STRAIN = _arg_int("seed-count-per-strain", 10)
     ENGINE = str(_args.get("engine") or "numpy").lower()
     if ENGINE != "numpy":
         raise ValueError(f"engine must be 'numpy', got {ENGINE!r}")
@@ -134,6 +142,27 @@ def delimit_simulation(mo):
     call to `update_simulation`. A seeded strain is thus always observed
     at update `0`, keeping the `-1` "never added" sentinel disjoint from
     every added strain's last-observed update.
+
+    This is written as the `strainlast` parquet (8 rows per replicate).
+
+    ### Susceptibility snapshots (`susc` parquet)
+
+    A second output records, **every `SUSC_WINDOW` (1000) updates**, a
+    snapshot of the population's average susceptibility to each of the
+    eight strains, **time-averaged over the trailing `SUSC_WINDOW`
+    updates**. A host's susceptibility to a strain is the
+    infection-probability factor from the shared model
+    (`calc_infection_probabilities`): the product over sites of
+    `1 - IMMUNE_STRENGTH * immunity` for the allele that strain carries
+    at each site. Following the founder notebook's `avg_susc` convention,
+    currently-infected hosts (which cannot be re-infected) contribute
+    zero, and the mean is taken over the full `POP_SIZE`. Each update's
+    per-strain population mean is accumulated, and at every multiple of
+    `SUSC_WINDOW` the window mean is emitted and the accumulator reset ---
+    so each snapshot is the average over updates `(t - SUSC_WINDOW, t]`.
+    This yields **8 rows (one per strain) per 1000-update window**, i.e.
+    `8 * (N_STEPS // SUSC_WINDOW)` rows per replicate (any trailing
+    updates past the last whole window are not emitted).
 
     Every output row is stamped with the simulation parameters as
     constant-valued columns, the `array_id`, and a `replicate_uid`
@@ -223,6 +252,40 @@ def run_replicate(
             for g in present.tolist():
                 last_observed[int(g)] = update
 
+    # Windowed susceptibility snapshots. strain_bits_mat[g, s] is bit s of
+    # genome g; it drives a vectorized per-strain susceptibility that is
+    # accumulated every update and averaged over each SUSC_WINDOW-update
+    # window (see mean_susceptibility_per_strain and the docstring above).
+    SUSC_WINDOW = 1000
+    strain_bits_mat = (
+        xp.arange(n_strains)[:, None] >> xp.arange(N_SITES)[None, :]
+    ) & 1
+
+    def mean_susceptibility_per_strain():
+        # Per-host susceptibility to each strain g == the product over
+        # sites of (1 - IMMUNE_STRENGTH * immunity) for the allele g
+        # carries at that site (calc_infection_probabilities, vectorized
+        # over all 8 strains at once). Currently-infected hosts contribute
+        # 0 and the mean is over the full POP_SIZE (founder avg_susc
+        # convention). Returns a length-n_strains vector.
+        susc = (
+            xp.float32(1.0) - xp.float32(IMMUNE_STRENGTH) * host_immunities
+        ).reshape(POP_SIZE, N_SITES, 2)
+        per = xp.ones((POP_SIZE, n_strains), dtype=xp.float32)
+        for s in range(N_SITES):
+            bit = strain_bits_mat[:, s]
+            per *= xp.where(
+                bit[None, :] == 0,
+                susc[:, s, 0][:, None],
+                susc[:, s, 1][:, None],
+            )
+        per *= (host_statuses == 0)[:, None]
+        return per.mean(axis=0, dtype=xp.float64)
+
+    susc_sum = xp.zeros(n_strains, dtype=xp.float64)
+    susc_count = 0
+    susc_rows = []
+
     observe(0)  # post-seeding snapshot (community as seeded)
     for t in range(1, N_STEPS + 1):
         host_statuses, pathogen_genomes, host_immunities = update_simulation(
@@ -246,6 +309,26 @@ def run_replicate(
             xp=xp,
         )
         observe(t)
+
+        # Accumulate this update's per-strain susceptibility; at each whole
+        # SUSC_WINDOW boundary emit the window mean (8 rows) and reset.
+        susc_sum += mean_susceptibility_per_strain()
+        susc_count += 1
+        if t % SUSC_WINDOW == 0:
+            window_mean = susc_sum / susc_count
+            for g in range(n_strains):
+                susc_rows.append(
+                    {
+                        "array_id": ARRAY_ID,
+                        "strain": g,
+                        "strain_bits": format(g, f"0{N_SITES}b"),
+                        "window_end_update": t,
+                        "window_size": susc_count,
+                        "mean_susceptibility": float(window_mean[g]),
+                    }
+                )
+            susc_sum = xp.zeros(n_strains, dtype=xp.float64)
+            susc_count = 0
 
     # One row per strain (genome 0..7). strain_bits is the plain
     # N_SITES-bit binary label of the genome integer (strain 0 -> "000",
@@ -285,6 +368,40 @@ def run_replicate(
     }
     strainlast_df = strainlast_df.assign(**params)
 
+    # Windowed susceptibility snapshots: 8 rows (one per strain) per whole
+    # SUSC_WINDOW-update window. Explicit columns keep the schema stable
+    # even when there is no whole window (N_STEPS < SUSC_WINDOW).
+    susc_df = (
+        pd.DataFrame(
+            susc_rows,
+            columns=[
+                "array_id",
+                "strain",
+                "strain_bits",
+                "window_end_update",
+                "window_size",
+                "mean_susceptibility",
+            ],
+        )
+        .astype(
+            {
+                # Pin dtypes so the parquet schema is identical whether or
+                # not any whole window was emitted --- an empty frame would
+                # otherwise default its columns to object/null and break the
+                # cross-replicate parquet concatenation. strain_bits uses
+                # the pandas "string" dtype so it is written as parquet
+                # `string` (not `null`) even when the frame has no rows.
+                "array_id": "int64",
+                "strain": "int64",
+                "strain_bits": "string",
+                "window_end_update": "int64",
+                "window_size": "int64",
+                "mean_susceptibility": "float64",
+            }
+        )
+        .assign(**params)
+    )
+
     nbname = pathlib.Path(__file__).stem
     out_dir = pathlib.Path("outdata") / nbname
 
@@ -296,9 +413,11 @@ def run_replicate(
         print(f"  wrote {kind} parquet ({len(df)} rows): {rep_path}")
 
     _save("strainlast", strainlast_df)
+    _save("susc", susc_df)
 
     print(strainlast_df.to_string())
-    return (strainlast_df,)
+    print(susc_df.head(16).to_string())
+    return strainlast_df, susc_df
 
 
 if __name__ == "__main__":

--- a/bindle/2026-07-14-strain-persistence.py
+++ b/bindle/2026-07-14-strain-persistence.py
@@ -1,0 +1,305 @@
+import marimo
+
+__generated_with = "0.23.2"
+app = marimo.App(width="full")
+
+
+@app.cell
+def import_std():
+    import pathlib
+    import uuid
+
+    return pathlib, uuid
+
+
+@app.cell
+def import_pkg():
+    import marimo as mo
+    import numpy as np
+    import pandas as pd
+    from watermark import watermark
+
+    from pylib.abm_2026_03_16 import initialize_pop, update_simulation
+
+    return initialize_pop, mo, np, pd, update_simulation, watermark
+
+
+@app.cell(hide_code=True)
+def do_watermark(mo, watermark):
+    mo.md(
+        f"""
+    ```Text
+    {watermark(
+        current_date=True,
+        iso8601=True,
+        machine=True,
+        updated=True,
+        python=True,
+        iversions=True,
+        globals_=globals(),
+    )}
+    ```
+    """
+    )
+    return
+
+
+@app.cell
+def configure_args(mo):
+    # Command-line args for a single community-assembly replicate. Set
+    # them after a `--` separator, e.g.
+    #   marimo export ipynb 2026-07-14-strain-persistence.py -o out.ipynb \
+    #       -- --array-id 42 --seed 1 --n-steps 25000 --pop-size 1000000
+    # or `marimo edit 2026-07-14-strain-persistence.py -- --array-id 42`.
+    # Every arg has a default, so the notebook also runs with no args.
+    #
+    # This is a **3-site** model, so the strain count is fixed at
+    # 2 ** 3 == 8 (genomes 0..7). Which of those 8 strains is present in
+    # the initial community is read straight off the binary code of
+    # ARRAY_ID in [0, 255]: bit j of ARRAY_ID set  <=>  strain j (genome
+    # integer j) is seeded. Thus
+    #   ARRAY_ID = 0   (0b00000000) -> no strains,
+    #   ARRAY_ID = 1   (0b00000001) -> just strain 000 (genome 0),
+    #   ARRAY_ID = 2   (0b00000010) -> just strain 001 (genome 1),
+    #   ARRAY_ID = 3   (0b00000011) -> strains 000 and 001,
+    #   ...
+    #   ARRAY_ID = 255 (0b11111111) -> all eight strains.
+    # Enumerating ARRAY_ID over [0, 255] therefore walks every subset of
+    # the eight strains exactly once (256 communities x 8 strains = 2048
+    # output rows once concatenated across the array).
+    # Defaults are deliberately light so an unconfigured run (e.g. the
+    # bindle CI that executes every notebook with no args) finishes
+    # quickly; the launch script overrides POP_SIZE / N_STEPS with the
+    # production values. ARRAY_ID defaults to 3 (strains 000 and 001) so
+    # the unconfigured run still exercises the seed / observe / save path
+    # rather than the empty ARRAY_ID=0 community.
+    _args = mo.cli_args()
+    ARRAY_ID = int(_args.get("array-id") or 3)
+    SEED = int(_args.get("seed") or 1)
+    POP_SIZE = int(_args.get("pop-size") or 100_000)
+    N_STEPS = int(_args.get("n-steps") or 1_200)
+    SEED_COUNT_PER_STRAIN = int(_args.get("seed-count-per-strain") or 10)
+    ENGINE = str(_args.get("engine") or "numpy").lower()
+    if ENGINE != "numpy":
+        raise ValueError(f"engine must be 'numpy', got {ENGINE!r}")
+    # Accepted for launch-script compatibility; this notebook renders no
+    # figures, so it is a no-op here.
+    SKIP_PLOTTING = bool(_args.get("skip-plotting") or False)
+    if not 0 <= ARRAY_ID <= 255:
+        raise ValueError(f"array-id must be in [0, 255], got {ARRAY_ID}")
+    print(
+        f"args: ARRAY_ID={ARRAY_ID} SEED={SEED} POP_SIZE={POP_SIZE} "
+        f"N_STEPS={N_STEPS} SEED_COUNT_PER_STRAIN={SEED_COUNT_PER_STRAIN} "
+        f"ENGINE={ENGINE} SKIP_PLOTTING={SKIP_PLOTTING}",
+    )
+    return ARRAY_ID, N_STEPS, POP_SIZE, SEED, SEED_COUNT_PER_STRAIN, ENGINE
+
+
+@app.cell(hide_code=True)
+def delimit_simulation(mo):
+    mo.md(
+        """
+    ## Simulation Implementation
+
+    This notebook runs a *single replicate* of the allele-based
+    agent-based model (ABM) for one initial community, using the shared
+    `pylib.abm_2026_03_16` step primitives (`initialize_pop`,
+    `update_simulation`). It is fixed to the **3-site** model, so there
+    are `2 ** 3 == 8` possible strains (genome integers `0..7`).
+
+    The initial community is decoded from the `--array-id` command-line
+    argument's binary representation: bit `j` of `array_id` selects
+    strain `j`. The seeded strains are **mixed equally** ---
+    `--seed-count-per-strain` hosts are seeded for *each* strain in the
+    community, at distinct host indices --- and the run proceeds forward
+    **without mutation** (`MUTATION_RATE = 0`), so the only genomes that
+    ever circulate are the seeded ones. A strain therefore either
+    persists to the end of the run or goes extinct; it is never
+    (re)created by mutation.
+
+    The single per-replicate deliverable is, for each of the eight
+    strains, **the last simulation update at which that strain was
+    observed** (i.e. the largest step index at which at least one host
+    carried that genome):
+
+    * `-1` --- the strain was never added to this community (its bit is
+      clear in `array_id`).
+    * `N_STEPS` --- the strain was added and never went extinct (it was
+      still circulating at the final update).
+    * `0 <= u < N_STEPS` --- the strain was added but went extinct; `u`
+      is the last update at which it was still observed.
+
+    Update index `0` is the post-seeding snapshot (the community as
+    seeded, before any dynamics), and updates `1..N_STEPS` follow each
+    call to `update_simulation`. A seeded strain is thus always observed
+    at update `0`, keeping the `-1` "never added" sentinel disjoint from
+    every added strain's last-observed update.
+
+    Every output row is stamped with the simulation parameters as
+    constant-valued columns, the `array_id`, and a `replicate_uid`
+    generated with the standard-library `uuid` module, so rows are
+    self-describing and uniquely identifiable.
+    """
+    )
+    return
+
+
+@app.cell
+def run_replicate(
+    ARRAY_ID,
+    ENGINE,
+    N_STEPS,
+    POP_SIZE,
+    SEED,
+    SEED_COUNT_PER_STRAIN,
+    initialize_pop,
+    np,
+    pathlib,
+    pd,
+    update_simulation,
+    uuid,
+):
+    # Fixed model / epidemiological parameters. N_SITES is fixed at 3
+    # (the 3-site model, 8 strains). MUTATION_RATE is fixed at 0 --- the
+    # community is run forward without mutation. The remaining
+    # epidemiological settings mirror the founder notebook
+    # 2026-05-20-founder.py.
+    N_SITES = 3
+    MUTATION_RATE = 0.0
+    CONTACT_RATE = 0.35
+    RECOVERY_RATE = 0.1
+    WANING_RATE = 0.01
+    IMMUNE_STRENGTH = 0.7
+    IMMUNITY_FLOOR = 0.05
+    IMMUNITY_CEILING = 1.0
+    WITHIN_HOST_B = 0.2
+    WITHIN_HOST_T = 25.0
+
+    n_strains = 1 << N_SITES  # 8
+
+    xp = np
+    np.random.seed(SEED)
+    xp.random.seed(SEED)
+
+    # Decode the initial community from array_id's binary code: bit j set
+    # <=> strain j (genome integer j) is seeded.
+    seeded_strains = [g for g in range(n_strains) if (ARRAY_ID >> g) & 1]
+
+    replicate_uid = uuid.uuid4().hex
+    print(
+        f"=== strain-persistence run: array_id={ARRAY_ID} "
+        f"seeded_strains={seeded_strains} seed={SEED} pop_size={POP_SIZE} "
+        f"n_steps={N_STEPS} uid={replicate_uid} ===",
+    )
+
+    host_statuses, pathogen_genomes, host_immunities = initialize_pop(
+        POP_SIZE, N_SITES, xp=xp
+    )
+
+    # Seed the community, mixing the selected strains equally:
+    # SEED_COUNT_PER_STRAIN hosts per strain, at distinct host indices.
+    if seeded_strains:
+        n_seed = SEED_COUNT_PER_STRAIN * len(seeded_strains)
+        if n_seed > POP_SIZE:
+            raise ValueError(
+                f"cannot seed {n_seed} hosts into POP_SIZE={POP_SIZE}",
+            )
+        seed_idx = xp.random.choice(POP_SIZE, size=n_seed, replace=False)
+        for k, g in enumerate(seeded_strains):
+            block = seed_idx[
+                k * SEED_COUNT_PER_STRAIN : (k + 1) * SEED_COUNT_PER_STRAIN
+            ]
+            host_statuses[block] = 1
+            pathogen_genomes[block] = g
+
+    # last_observed[g]: largest update index at which genome g was seen;
+    # -1 means "never added" (updated only for genomes actually present).
+    last_observed = {g: -1 for g in range(n_strains)}
+
+    def observe(update: int) -> None:
+        inf_mask = host_statuses > 0
+        if xp.any(inf_mask):
+            present = xp.unique(pathogen_genomes[inf_mask])
+            for g in present.tolist():
+                last_observed[int(g)] = update
+
+    observe(0)  # post-seeding snapshot (community as seeded)
+    for t in range(1, N_STEPS + 1):
+        host_statuses, pathogen_genomes, host_immunities = update_simulation(
+            host_statuses,
+            pathogen_genomes,
+            host_immunities,
+            POP_SIZE,
+            N_SITES,
+            CONTACT_RATE,
+            IMMUNE_STRENGTH,
+            RECOVERY_RATE,
+            WANING_RATE,
+            MUTATION_RATE,
+            WITHIN_HOST_B,
+            WITHIN_HOST_T,
+            0,  # MUTATOR_HOSTS_N
+            1.0,  # MUTATOR_HOSTS_MX
+            0.0,  # MUTATION_THRESHOLD
+            IMMUNITY_CEILING,
+            IMMUNITY_FLOOR,
+            xp=xp,
+        )
+        observe(t)
+
+    # One row per strain (genome 0..7). strain_bits is the plain
+    # N_SITES-bit binary label of the genome integer (strain 0 -> "000",
+    # strain 1 -> "001", ...), matching the array_id bit <-> strain
+    # mapping documented above.
+    rows = []
+    for g in range(n_strains):
+        rows.append(
+            {
+                "array_id": ARRAY_ID,
+                "strain": g,
+                "strain_bits": format(g, f"0{N_SITES}b"),
+                "last_observed_update": last_observed[g],
+            }
+        )
+    strainlast_df = pd.DataFrame(rows)
+
+    # Simulation parameters recorded as constant-valued columns so each
+    # output row is self-describing, plus the replicate UUID.
+    params = {
+        "replicate_uid": replicate_uid,
+        "array_id": ARRAY_ID,
+        "seed": SEED,
+        "n_sites": N_SITES,
+        "n_strains": n_strains,
+        "pop_size": POP_SIZE,
+        "n_steps": N_STEPS,
+        "engine": ENGINE,
+        "mutation_rate": MUTATION_RATE,
+        "contact_rate": CONTACT_RATE,
+        "recovery_rate": RECOVERY_RATE,
+        "waning_rate": WANING_RATE,
+        "immune_strength": IMMUNE_STRENGTH,
+        "seed_count_per_strain": SEED_COUNT_PER_STRAIN,
+        "immunity_floor": IMMUNITY_FLOOR,
+        "immunity_ceiling": IMMUNITY_CEILING,
+    }
+    strainlast_df = strainlast_df.assign(**params)
+
+    nbname = pathlib.Path(__file__).stem
+    out_dir = pathlib.Path("outdata") / nbname
+
+    def _save(kind, df):
+        rep_dir = out_dir / kind / replicate_uid
+        rep_dir.mkdir(parents=True, exist_ok=True)
+        rep_path = rep_dir / f"a={kind}+what={nbname}+ext=.pqt"
+        df.to_parquet(rep_path, index=False)
+        print(f"  wrote {kind} parquet ({len(df)} rows): {rep_path}")
+
+    _save("strainlast", strainlast_df)
+
+    print(strainlast_df.to_string())
+    return (strainlast_df,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/slurm/2026-07-14/2026-07-14-strain-persistence-array.sh
+++ b/slurm/2026-07-14/2026-07-14-strain-persistence-array.sh
@@ -1,0 +1,427 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+echo "configuration ==========================================================="
+JOBDATE="$(date '+%Y-%m-%d')"
+echo "JOBDATE ${JOBDATE}"
+
+JOBNAME="$(basename -s .sh "$0")"
+echo "JOBNAME ${JOBNAME}"
+
+JOBPROJECT="$(basename -s .git "$(git remote get-url origin)")"
+echo "JOBPROJECT ${JOBPROJECT}"
+
+NOTEBOOK_NAME="2026-07-14-strain-persistence"
+echo "NOTEBOOK_NAME ${NOTEBOOK_NAME}"
+NOTEBOOK_PATH="bindle/${NOTEBOOK_NAME}.py"
+echo "NOTEBOOK_PATH ${NOTEBOOK_PATH}"
+
+# Community-assembly sweep over the 3-site model (N_SITES=3, so 2 ** 3 =
+# 8 strains, genomes 0..7). Each array task t in [0, 255] initializes one
+# community whose seeded strains are read off the binary code of t: bit j
+# of t set <=> strain j (genome integer j) is seeded. Enumerating t over
+# [0, 255] walks every subset of the 8 strains exactly once (256
+# communities). The seeded strains are mixed equally --- SEED_COUNT_PER_-
+# STRAIN hosts per strain --- and each community is run forward WITHOUT
+# mutation (the notebook fixes MUTATION_RATE=0), so the only genomes that
+# ever circulate are the seeded ones.
+#
+# One replicate per array task (SEED=1); there are exactly 256 array
+# tasks, well under the cluster's 1000-task cap, so --- unlike the packed
+# mutation sweeps --- there is no per-task CHUNK concurrency here. Each
+# replicate emits a single "strainlast" parquet of 8 rows (one per
+# strain) recording the last update at which each strain was observed
+# (-1 = strain never added to this community; N_STEPS = strain added and
+# never went extinct; 0 <= u < N_STEPS = strain added but went extinct at
+# update u). Concatenating across the array yields 256 * 8 = 2048 rows.
+N_SITES=3
+N_STRAINS=$((1 << N_SITES))
+N_ARRAY_TASKS=256
+SEED=1
+N_STEPS=25000
+POP_SIZE=1000000
+SEED_COUNT_PER_STRAIN=10
+echo "N_SITES=${N_SITES} N_STRAINS=${N_STRAINS} N_ARRAY_TASKS=${N_ARRAY_TASKS}"
+echo "SEED=${SEED} N_STEPS=${N_STEPS} POP_SIZE=${POP_SIZE}"
+echo "SEED_COUNT_PER_STRAIN=${SEED_COUNT_PER_STRAIN}"
+
+SOURCE_REVISION="$(git rev-parse HEAD)"
+echo "SOURCE_REVISION ${SOURCE_REVISION}"
+SOURCE_REMOTE_URL="$(git config --get remote.origin.url)"
+echo "SOURCE_REMOTE_URL ${SOURCE_REMOTE_URL}"
+
+echo "initialization telemetry ==============================================="
+echo "date $(date)"
+echo "hostname $(hostname)"
+echo "PWD ${PWD}"
+echo "SLURM_JOB_ID ${SLURM_JOB_ID:-nojid}"
+echo "SLURM_ARRAY_TASK_ID ${SLURM_ARRAY_TASK_ID:-notid}"
+module purge || :
+module load Python/3.10.8 || :
+echo "python3.10 $(which python3.10)"
+echo "python3.10 --version $(python3.10 --version)"
+
+echo "setup HOME dirs ========================================================"
+mkdir -p "${HOME}/joblatest"
+mkdir -p "${HOME}/joblog"
+mkdir -p "${HOME}/jobscript"
+if ! [ -e "${HOME}/scratch" ]; then
+    if [ -e "/mnt/scratch/${USER}" ]; then
+        ln -s "/mnt/scratch/${USER}" "${HOME}/scratch" || :
+    else
+        mkdir -p "${HOME}/scratch" || :
+    fi
+fi
+
+echo "setup BATCHDIR =========================================================="
+BATCHDIR="${HOME}/scratch/${JOBPROJECT}/${JOBNAME}/${JOBDATE}"
+if [ -e "${BATCHDIR}" ]; then
+    echo "BATCHDIR ${BATCHDIR} exists, clearing it"
+fi
+rm -rf "${BATCHDIR}"
+mkdir -p "${BATCHDIR}"
+echo "BATCHDIR ${BATCHDIR}"
+
+echo "symlinking latest"
+LATESTDIR="${HOME}/scratch/${JOBPROJECT}/${JOBNAME}/latest"
+echo "${BATCHDIR} > ${LATESTDIR}"
+ln -sfn "${BATCHDIR}" "${LATESTDIR}"
+
+BATCHDIR_JOBLOG="${BATCHDIR}/joblog"
+echo "BATCHDIR_JOBLOG ${BATCHDIR_JOBLOG}"
+mkdir -p "${BATCHDIR_JOBLOG}"
+
+BATCHDIR_JOBRESULT="${BATCHDIR}/jobresult"
+echo "BATCHDIR_JOBRESULT ${BATCHDIR_JOBRESULT}"
+mkdir -p "${BATCHDIR_JOBRESULT}"
+
+BATCHDIR_JOBSCRIPT="${BATCHDIR}/jobscript"
+echo "BATCHDIR_JOBSCRIPT ${BATCHDIR_JOBSCRIPT}"
+mkdir -p "${BATCHDIR_JOBSCRIPT}"
+
+BATCHDIR_JOBSOURCE="${BATCHDIR}/_jobsource"
+echo "BATCHDIR_JOBSOURCE ${BATCHDIR_JOBSOURCE}"
+if [[ $* == *--dirty* ]]; then
+    cp -r "$(git rev-parse --show-toplevel)" "${BATCHDIR_JOBSOURCE}"
+else
+    mkdir -p "${BATCHDIR_JOBSOURCE}"
+    for attempt in {1..5}; do
+        rm -rf "${BATCHDIR_JOBSOURCE}/.git"
+        git -C "${BATCHDIR_JOBSOURCE}" init \
+        && git -C "${BATCHDIR_JOBSOURCE}" remote add origin "${SOURCE_REMOTE_URL}" \
+        && git -C "${BATCHDIR_JOBSOURCE}" fetch origin "${SOURCE_REVISION}" --depth=1 \
+        && git -C "${BATCHDIR_JOBSOURCE}" reset --hard FETCH_HEAD \
+        && break || echo "failed to clone, retrying..."
+        if [ $attempt -eq 5 ]; then
+            echo "failed to clone, failing"
+            exit 1
+        fi
+        sleep 5
+    done
+fi
+
+BATCHDIR_ENV="${BATCHDIR}/_jobenv"
+python3.10 -m venv --system-site-packages "${BATCHDIR_ENV}"
+source "${BATCHDIR_ENV}/bin/activate"
+echo "python3.10 $(which python3.10)"
+echo "python3.10 --version $(python3.10 --version)"
+for attempt in {1..5}; do
+    python3.10 -m pip install --upgrade pip 'setuptools<75' wheel || :
+    python3.10 -m pip install --upgrade uv \
+    && python3.10 -m uv pip install joinem==0.11.1 \
+    && python3.10 -m uv pip install \
+        -r "${BATCHDIR_JOBSOURCE}/requirements.txt" \
+    && break || echo "pip install attempt ${attempt} failed"
+    if [ ${attempt} -eq 5 ]; then
+        echo "pip install failed"
+        exit 1
+    fi
+done
+
+echo "setup dependencies ========================================== \${SECONDS}"
+source "${BATCHDIR_ENV}/bin/activate"
+python3.10 -m uv pip freeze
+
+echo "sbatch preamble ========================================================="
+JOB_PREAMBLE=$(cat << EOF
+set -e
+shopt -s globstar
+
+# adapted from https://unix.stackexchange.com/a/504829
+handlefail() {
+    echo ">>>error<<<" || :
+    awk 'NR>L-4 && NR<L+4 { printf "%-5d%3s%s\n",NR,(NR==L?">>>":""),\$0 }' L=\$1 \$0 || :
+    ln -sfn "\${JOBSCRIPT}" "\${HOME}/joblatest/jobscript.failed" || :
+    ln -sfn "\${JOBLOG}" "\${HOME}/joblatest/joblog.failed" || :
+    $(which scontrol || which echo) requeuehold "${SLURM_JOBID:-nojid}"
+}
+trap 'handlefail $LINENO' ERR
+
+echo "initialization telemetry ------------------------------------ \${SECONDS}"
+echo "SOURCE_REVISION ${SOURCE_REVISION}"
+echo "BATCHDIR ${BATCHDIR}"
+
+echo "cc SLURM script --------------------------------------------- \${SECONDS}"
+JOBSCRIPT="\${HOME}/jobscript/\${SLURM_JOB_ID:-nojid}"
+echo "JOBSCRIPT \${JOBSCRIPT}"
+cp "\${0}" "\${JOBSCRIPT}"
+chmod +x "\${JOBSCRIPT}"
+cp "\${JOBSCRIPT}" "${BATCHDIR_JOBSCRIPT}/\${SLURM_JOB_ID:-nojid}"
+ln -sfn "\${JOBSCRIPT}" "${HOME}/joblatest/jobscript.launched"
+
+echo "cc job log -------------------------------------------------- \${SECONDS}"
+JOBLOG="\${HOME}/joblog/\${SLURM_JOB_ID:-nojid}"
+echo "JOBLOG \${JOBLOG}"
+touch "\${JOBLOG}"
+ln -sfn "\${JOBLOG}" "${BATCHDIR_JOBLOG}/\${SLURM_JOB_ID:-nojid}"
+ln -sfn "\${JOBLOG}" "\${HOME}/joblatest/joblog.launched"
+
+echo "setup JOBDIR ------------------------------------------------ \${SECONDS}"
+JOBDIR="${BATCHDIR}/__\${SLURM_ARRAY_TASK_ID:-\${SLURM_JOB_ID:-\${RANDOM}}}"
+echo "JOBDIR \${JOBDIR}"
+if [ -e "\${JOBDIR}" ]; then
+    echo "JOBDIR \${JOBDIR} exists, clearing it"
+fi
+rm -rf "\${JOBDIR}"
+mkdir -p "\${JOBDIR}"
+cd "\${JOBDIR}"
+echo "PWD \${PWD}"
+
+echo "job telemetry ----------------------------------------------- \${SECONDS}"
+echo "source SLURM_JOB_ID ${SLURM_JOB_ID:-nojid}"
+echo "current SLURM_JOB_ID \${SLURM_JOB_ID:-nojid}"
+echo "SLURM_ARRAY_TASK_ID \${SLURM_ARRAY_TASK_ID:-notid}"
+echo "hostname \$(hostname)"
+echo "date \$(date)"
+
+echo "module setup ------------------------------------------------ \${SECONDS}"
+module purge || :
+module load Python/3.10.8 || :
+echo "python3.10 \$(which python3.10)"
+echo "python3.10 --version \$(python3.10 --version)"
+
+echo "setup dependencies- ----------------------------------------- \${SECONDS}"
+source "${BATCHDIR_ENV}/bin/activate"
+python3.10 -m uv pip freeze
+
+EOF
+)
+
+echo "create sbatch file: work ==============================================="
+
+SBATCH_FILE="$(mktemp)"
+echo "SBATCH_FILE ${SBATCH_FILE}"
+
+###############################################################################
+# WORK ---------------------------------------------------------------------- #
+###############################################################################
+cat > "${SBATCH_FILE}" << EOF
+#!/bin/bash
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=16G
+#SBATCH --time=8:00:00
+#SBATCH --output="/mnt/home/%u/joblog/%j"
+#SBATCH --mail-user=mawni4ah2o@pomail.net
+#SBATCH --mail-type=FAIL,TIME_LIMIT,ARRAY_TASKS
+#SBATCH --account=ecode
+#SBATCH --requeue
+#SBATCH --array=0-$((N_ARRAY_TASKS - 1))
+
+${JOB_PREAMBLE}
+
+echo "lscpu ------------------------------------------------------- \${SECONDS}"
+lscpu || :
+
+echo "cpuinfo ----------------------------------------------------- \${SECONDS}"
+cat /proc/cpuinfo || :
+
+echo "marimo notebook source -------------------------------------- \${SECONDS}"
+echo "notebook source: ${BATCHDIR_JOBSOURCE}/${NOTEBOOK_PATH}"
+cat "${BATCHDIR_JOBSOURCE}/${NOTEBOOK_PATH}" || :
+
+echo "task assignment --------------------------------------------- \${SECONDS}"
+# The array task id IS the community index (array_id) --- its 8-bit
+# binary code selects which of the 8 strains are seeded (see notebook).
+ARRAY_ID=\${SLURM_ARRAY_TASK_ID:-0}
+echo "ARRAY_ID=\${ARRAY_ID} N_SITES=${N_SITES} SEED=${SEED}"
+printf 'community bits: %08d\n' "\$(echo "obase=2; \${ARRAY_ID}" | bc)" || :
+
+# Single-threaded numpy so the one replicate stays within its one CPU
+# (--cpus-per-task=1).
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+
+echo "do work ----------------------------------------------------- \${SECONDS}"
+# Run one community replicate on CPU (engine=numpy). The notebook writes
+# its single "strainlast" parquet to
+# outdata/${NOTEBOOK_NAME}/strainlast/<uid>/... with the simulation
+# parameters, the array_id, and a uuid replicate identifier stamped onto
+# every row, so the community is fully recoverable downstream.
+#
+# Export from a PRIVATE per-task copy of the notebook. Every array task
+# would otherwise run marimo against the same notebook file inside the
+# single _jobsource clone on the network filesystem; under that
+# concurrency marimo can clobber the shared source to an empty default
+# stub, after which later exports yield a blank notebook with no outdata.
+# A private copy removes that shared-file race. The notebook does
+# 'from pylib import ...', and marimo puts the notebook's own directory
+# on sys.path, so the private copy sits beside a pylib symlink.
+NBDIR="\${JOBDIR}/_nb"
+mkdir -p "\${NBDIR}"
+cp "${BATCHDIR_JOBSOURCE}/${NOTEBOOK_PATH}" "\${NBDIR}/${NOTEBOOK_NAME}.py"
+ln -sfn "${BATCHDIR_JOBSOURCE}/pylib" "\${NBDIR}/pylib"
+
+MPLBACKEND=Agg python3.10 -m marimo export ipynb \
+    --include-outputs --sort topological -f \
+    "\${NBDIR}/${NOTEBOOK_NAME}.py" \
+    -o "\${JOBDIR}/${NOTEBOOK_NAME}.ipynb" \
+    -- \
+    --array-id "\${ARRAY_ID}" \
+    --seed ${SEED} \
+    --n-steps ${N_STEPS} \
+    --pop-size ${POP_SIZE} \
+    --seed-count-per-strain ${SEED_COUNT_PER_STRAIN} \
+    --engine numpy \
+    --skip-plotting True
+
+# Fail loudly on a blank/failed export. marimo can exit 0 while producing
+# a notebook whose cells never executed --- and the run cell is what
+# writes the parquet --- so a "successful" export with no outputs would
+# otherwise sail through to >>>complete<<<. Require both a non-trivial
+# exported notebook and the run cell's parquet output under outdata/<nb>/.
+NB_OUT="\${JOBDIR}/${NOTEBOOK_NAME}.ipynb"
+OUTDATA_DIR="\${JOBDIR}/outdata/${NOTEBOOK_NAME}"
+NB_BYTES=\$(wc -c < "\${NB_OUT}" 2>/dev/null || echo 0)
+if [ "\${NB_BYTES}" -lt 10000 ]; then
+    echo "ERROR [array_id=\${ARRAY_ID}]: exported notebook \${NB_OUT} missing or trivial (\${NB_BYTES} bytes)"
+    exit 1
+fi
+N_PQT=\$(find "\${OUTDATA_DIR}" -name 'a=*+ext=.pqt' 2>/dev/null | wc -l)
+if [ "\${N_PQT}" -lt 1 ]; then
+    echo "ERROR [array_id=\${ARRAY_ID}]: no parquet outputs under \${OUTDATA_DIR} (notebook produced no outdata)"
+    exit 1
+fi
+echo "  [array_id=\${ARRAY_ID}] export OK: \${NB_BYTES} byte notebook, \${N_PQT} parquet(s) in outdata"
+
+echo "finalization telemetry -------------------------------------- \${SECONDS}"
+ls -lR "\${JOBDIR}" | head -200
+du -sh "\${JOBDIR}"
+ln -sfn "\${JOBSCRIPT}" "${HOME}/joblatest/jobscript.finished"
+ln -sfn "\${JOBLOG}" "${HOME}/joblatest/joblog.finished"
+echo "SECONDS \${SECONDS}"
+echo '>>>complete<<<'
+
+EOF
+###############################################################################
+# --------------------------------------------------------------------------- #
+###############################################################################
+
+
+echo "submit sbatch file ====================================================="
+$(which sbatch && echo --job-name="${JOBNAME}" || which bash) "${SBATCH_FILE}"
+
+echo "create sbatch file: collate ============================================"
+
+SBATCH_FILE="$(mktemp)"
+echo "SBATCH_FILE ${SBATCH_FILE}"
+
+###############################################################################
+# COLLATE ------------------------------------------------------------------- #
+###############################################################################
+cat > "${SBATCH_FILE}" << EOF
+#!/bin/bash
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=16G
+#SBATCH --time=4:00:00
+#SBATCH --output="/mnt/home/%u/joblog/%j"
+#SBATCH --mail-user=mawni4ah2o@pomail.net
+#SBATCH --mail-type=ALL
+#SBATCH --account=ecode
+#SBATCH --requeue
+
+${JOB_PREAMBLE}
+
+echo "BATCHDIR ${BATCHDIR}"
+ls -l "${BATCHDIR}"
+
+echo "finalize ---------------------------------------------------- \${SECONDS}"
+echo "   - archive job dir"
+pushd "${BATCHDIR}/.."
+    tar czf \
+    "${BATCHDIR_JOBRESULT}/a=jobarchive+date=${JOBDATE}+job=${JOBNAME}+ext=.tar.gz" \
+    "\$(basename "${BATCHDIR}")"/__*
+popd
+
+echo "   - join per-replicate parquets across all communities"
+# Each per-replicate parquet already carries the replicate_uid, the
+# array_id, and the condition columns (n_sites, pop_size, n_steps, seed,
+# engine, mutation_rate, ...) stamped by the notebook's run cell, so a
+# straight concatenation yields a self-describing collated frame. The
+# strainlast parquet is the sole output --- 8 rows per replicate (one per
+# strain) recording each strain's last-observed update. 256 communities
+# x 8 strains = 2048 rows in the joined frame.
+for kind in strainlast; do
+    echo "    joining \${kind} ..."
+    out_path="${BATCHDIR_JOBRESULT}/a=\${kind}+date=${JOBDATE}+job=${JOBNAME}+ext=.pqt"
+    # __<arrayid>/outdata/... --- one output dir per array task (globstar
+    # ** also tolerates a nested layout).
+    ls -1 "${BATCHDIR}"/__*/**/outdata/${NOTEBOOK_NAME}/\${kind}/*/a=\${kind}+*+ext=.pqt 2>/dev/null \
+        | tee /dev/stderr \
+        | python3.10 -m joinem --progress "\${out_path}" \
+        || echo "no \${kind} files to join"
+done
+ls -l "${BATCHDIR_JOBRESULT}"
+du -h "${BATCHDIR_JOBRESULT}"
+
+echo "   - archive joblog"
+pushd "${BATCHDIR}"
+    tar czf \
+    "${BATCHDIR_JOBRESULT}/a=joblog+date=${JOBDATE}+job=${JOBNAME}+ext=.tar.gz" \
+    -h "\$(basename "${BATCHDIR_JOBLOG}")"
+popd
+
+echo "   - archive jobscript"
+pushd "${BATCHDIR}"
+    tar czf \
+    "\$(basename "${BATCHDIR_JOBRESULT}")/a=jobscript+date=${JOBDATE}+job=${JOBNAME}+ext=.tar.gz" \
+    -h "\$(basename ${BATCHDIR_JOBSCRIPT})"
+popd
+
+ls -l "${BATCHDIR}"
+
+echo "cleanup ----------------------------------------------------- \${SECONDS}"
+cd "${BATCHDIR}"
+for f in _*; do
+    echo "tar and rm \$f"
+    tar cf "\${f}.tar" -h "\${f}"
+    rm -rf "\${f}"
+done
+cd
+ls -l "${BATCHDIR}"
+
+echo "finalization telemetry -------------------------------------- \${SECONDS}"
+ln -sfn "\${JOBSCRIPT}" "\${HOME}/joblatest/jobscript.completed"
+ln -sfn "\${JOBLOG}" "\${HOME}/joblatest/joblog.completed"
+ln -sfn "${BATCHDIR_JOBRESULT}" "\${HOME}/joblatest/jobresult.completed"
+echo "SECONDS \${SECONDS}"
+echo '>>>complete<<<'
+
+EOF
+###############################################################################
+# --------------------------------------------------------------------------- #
+###############################################################################
+
+echo "submit sbatch file ====================================================="
+$(which sbatch && echo --job-name="${JOBNAME}" --dependency=singleton || which bash) "${SBATCH_FILE}"
+
+echo "finalization telemetry ================================================="
+echo "BATCHDIR ${BATCHDIR}"
+echo "SECONDS ${SECONDS}"
+echo '>>>complete<<<'

--- a/slurm/2026-07-14/2026-07-14-strain-persistence-array.sh
+++ b/slurm/2026-07-14/2026-07-14-strain-persistence-array.sh
@@ -363,11 +363,14 @@ echo "   - join per-replicate parquets across all communities"
 # Each per-replicate parquet already carries the replicate_uid, the
 # array_id, and the condition columns (n_sites, pop_size, n_steps, seed,
 # engine, mutation_rate, ...) stamped by the notebook's run cell, so a
-# straight concatenation yields a self-describing collated frame. The
-# strainlast parquet is the sole output --- 8 rows per replicate (one per
-# strain) recording each strain's last-observed update. 256 communities
-# x 8 strains = 2048 rows in the joined frame.
-for kind in strainlast; do
+# straight concatenation yields a self-describing collated frame.
+#   - strainlast: 8 rows per replicate (one per strain) recording each
+#     strain's last-observed update; 256 communities x 8 strains = 2048
+#     rows in the joined frame.
+#   - susc: 8 rows per strain per 1000-update window --- a trailing
+#     1000-update average of each strain's population-mean susceptibility,
+#     snapshotted every 1000 updates.
+for kind in strainlast susc; do
     echo "    joining \${kind} ..."
     out_path="${BATCHDIR_JOBRESULT}/a=\${kind}+date=${JOBDATE}+job=${JOBNAME}+ext=.pqt"
     # __<arrayid>/outdata/... --- one output dir per array task (globstar


### PR DESCRIPTION
Sweep every subset of the eight 3-site strains (genomes 0..7) as an
initial community. A new marimo notebook
bindle/2026-07-14-strain-persistence.py decodes the community from the
binary code of an --array-id in [0, 255] (bit j <=> strain j), seeds the
selected strains equally (SEED_COUNT_PER_STRAIN hosts each), and runs the
shared pylib.abm_2026_03_16 primitives forward without mutation
(MUTATION_RATE=0). Its single "strainlast" parquet has 8 rows (one per
strain) recording the last update each strain was observed at: -1 if never
added, N_STEPS if it never went extinct, else the extinction update. Rows
carry the configuration columns, array_id, and a uuid replicate_uid.

slurm/2026-07-14/2026-07-14-strain-persistence-array.sh follows the
existing sweep launch scripts (private per-task notebook copy, blank-export
guards, joinem collate) but runs one replicate per array task over
--array=0-255; concatenating yields 256 * 8 = 2048 rows.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DBDUSVBV5LDxqWGzaHCEgN